### PR TITLE
Add env variable $PSGI_BASE_URL so Is_LSMB_running.sh works

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,7 @@ services:
         source: ${PWD}
     environment:
       LSMB_BASE_URL: http://lsmb-${LSMB_DEV_VERSION}-devel:5762
+      PSGI_BASE_URL: http://lsmb-${LSMB_DEV_VERSION}-devel:5762
       LSMB_TEST_DB: 1
       LSMB_NEW_DB: lsmbtestdb
       POD_TESTING: 1


### PR DESCRIPTION
Is_LSMB_running.sh defaults to http://localhost:5001, but this container
uses port 5762, so an environment variable needs to be set.