### PR TITLE
Add LANG environment variable for selenium container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,8 @@ services:
     stop_signal: SIGKILL
     expose:
       - 4422
+    environment:
+      LANG: en_US.UTF-8
   lsmb:
     depends_on:
       - db


### PR DESCRIPTION
Failing to explicitly set the LANG variable for the selenium container causes tests involving
date formats to fail when the dojo date widget expects a different
date format to that used in the test definitions.

An example of such a test is xt/66-cucumber/01-basic/setup.feature