### PR TITLE
Fix Dockerfile missing line continuation in previous commit

### DIFF
--- a/ledgersmb/Dockerfile
+++ b/ledgersmb/Dockerfile
@@ -38,7 +38,7 @@ RUN DEBIAN_FRONTENT=noninteractive apt-get update && \
     libtemplate-plugin-latex-perl libtex-encode-perl \
     libmoosex-nonmoose-perl libclass-c3-xs-perl \
     texlive-latex-recommended \
-    libx12-parser-perl
+    libx12-parser-perl \
     texlive-xetex \
     starman \
     libxml-twig-perl libopenoffice-oodoc-perl \


### PR DESCRIPTION
Apologies - previous commit introduced a Dockerfile syntax error by
missing a line continutation character in the list of packages to
install. I now know how to test locally first :)