### PR TITLE
Add LSMB_IMAGE variable for lsmb image name in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     depends_on:
       - db
       - selenium
-    image: ledgersmb/ledgersmb-dev-lsmb
+    image: ${LSMB_IMAGE:-ledgersmb/ledgersmb-dev-lsmb}
     container_name: lsmb-${LSMB_DEV_VERSION}-devel
     links:
       - "db:postgres"


### PR DESCRIPTION
Environment variable `LSMB_IMAGE` may be used to specify the docker
image used for the lsmb/starman container.

By default, the previously hard-coded `ledgersmb/ledgersmb-dev-lsmb`
is used, but this can now be overridden by the enviroment variable.

This allows the same official `docker-compose.yml` file to be used with
alternative images, perhaps for testing a specific perl version.