### PR TITLE
Add docker build contexts for the perl versions we support

### DIFF
--- a/ledgersmb-dev-perl-5.10/Dockerfile
+++ b/ledgersmb-dev-perl-5.10/Dockerfile
@@ -1,0 +1,94 @@
+FROM perl:5.10
+MAINTAINER  Nick Prater nick@npbroadcast.com
+
+# ledgersmb development and test container created
+# from official perl images.
+
+# Dockerfile based on official ledgersmb/ledgersmb-dev-lsmb
+
+# No point installing perl libraries via apt-get as we're
+# using the official perl container, which doesn't use the
+# debian system libraries.
+#
+# gcc, cpanminus, git are already installed in the base perl image
+
+RUN echo -n "APT::Install-Recommends \"0\";\nAPT::Install-Suggests \"0\";\n" \
+       >> /etc/apt/apt.conf && \
+  DEBIAN_FRONTEND=noninteractive apt-get update && \
+  DEBIAN_FRONTEND=noninteractive apt-get -y install curl ca-certificates \
+                                            gnupg2 && \
+  curl -L https://deb.nodesource.com/setup_6.x -o ./setup && \
+  bash ./setup && rm ./setup && \
+  DEBIAN_FRONTEND=noninteractive apt-get update && \
+  DEBIAN_FRONTEND=noninteractive apt-get -y install \
+    postgresql-client \
+    texlive-latex-recommended \
+    texlive-xetex \
+    ssmtp \
+    nodejs lsb-release \
+    gettext procps  \
+  python-pip python-urllib3 python-six && \
+  pip install transifex-client && \
+  npm install -g uglify-js@">=2.0 <3.0"
+
+# 1.5 additional dependency install:
+#    JRE is for running the dojo build process using ClosureCompiler
+RUN DEBIAN_FRONTEND=noninteractive apt-get -y install \
+      default-jre-headless
+
+# Build time variables
+ENV NODE_PATH /usr/local/lib/node_modules
+ARG CACHEBUST
+
+# Install LedgerSMB
+RUN cd /srv && mkdir ledgersmb && cd ledgersmb && \
+  wget https://github.com/ledgersmb/LedgerSMB/raw/1.5/cpanfile && \
+  cpanm --quiet --notest \
+    --with-develop \
+    --with-feature=starman \
+    --with-feature=latex-pdf-images \
+    --with-feature=latex-pdf-ps \
+    --with-feature=openoffice \
+    --with-feature=edi \
+    --installdeps . && \
+  rm cpanfile && \
+  cpanm --quiet --notest Pod::ProjectDocs && \
+  rm -rf ~/.cpanm && \
+  cd .. && rm -rf ledgersmb && mkdir ledgersmb
+
+# Configure outgoing mail to use host, other run time variable defaults
+
+## sSMTP
+ENV SSMTP_ROOT ar@example.com
+ENV SSMTP_MAILHUB 172.17.0.1
+ENV SSMTP_HOSTNAME 172.17.0.1
+#ENV SSMTP_USE_STARTTLS
+#ENV SSMTP_AUTH_USER
+#ENV SSMTP_AUTH_PASS
+ENV SSMTP_FROMLINE_OVERRIDE YES
+#ENV SSMTP_AUTH_METHOD
+
+ENV POSTGRES_HOST postgres
+ENV POSTGRES_PORT 5432
+ENV DEFAULT_DB lsmb
+
+COPY start.sh /usr/local/bin/start.sh
+COPY update_ssmtp.sh /usr/local/bin/update_ssmtp.sh
+
+RUN chown www-data /etc/ssmtp /etc/ssmtp/ssmtp.conf && \
+  chmod +x /usr/local/bin/update_ssmtp.sh /usr/local/bin/start.sh && \
+  mkdir -p /var/www
+
+# Work around an aufs bug related to directory permissions:
+RUN mkdir -p /tmp && \
+  chmod 1777 /tmp
+
+# Internal Port Expose
+EXPOSE 5762
+# If ledgersmb.conf does not exist, www-data user needs to be able to create it.
+RUN chown www-data /srv/ledgersmb
+USER www-data
+
+WORKDIR /srv/ledgersmb
+
+CMD ["start.sh"]

--- a/ledgersmb-dev-perl-5.10/README.md
+++ b/ledgersmb-dev-perl-5.10/README.md
@@ -1,0 +1,111 @@
+# ledgersmb-docker
+Dockerfile for LedgerSMB Docker image
+
+This is a work in progress to make a docker image for running LedgerSMB. It should not be relied upon for production use!
+
+# Supported tags and respective `Dockerfile` links
+
+-	`dev-master` - Master branch from git, unstable
+- `1.5`, `1.5.x`, `latest` - Latest release tarball from 1.5 branch
+- `1.4`, `1.4.x` - Latest tagged release of git 1.4 branch
+
+
+# What is LedgerSMB?
+The LedgerSMB project's priority is to provide an extremely capable yet user-friendly accounting and ERP solution to small to mid-size businesses in all locales where there is interest in using the software. The focus on small to mid-size businesses offers an opportunity to provide a positive user experience in ways which are not present in larger organizations. LedgerSMB ought to strive to be both the ideal SMB accounting/ERP package and also a solution that a start-up will never outgrow. The goals mentioned above will help us provide this ideal solution by allowing us to focus both on technical architecture and on user experience.
+
+
+# How is this image designed to be used?
+
+This Docker image is built to provide a self-contained LedgerSMB instance. To be functional, you need to connect it to a running Postgres installation. The official Postgres container will work as is, if you link it to the LedgerSMB instance at startup, or you can provide environment variables to an appropriate Postgres server.
+
+LedgerSMB provides an http interface built on Starman out of the box, listening on port 5762. We do not recommend exposing this port, because we strongly recommend encrypting all connections using SSL/TLS. For production use, we recommend running a web server configured with SSL, such as Nginx or Apache, and proxying connections to LedgerSMB.
+
+The other services you will need to put this in production are an SMTP gateway (set environment variables for SSMTP at container startup) and optionally a local print server (e.g. CUPS) installation. The print service is not currently supported in this Docker image, but pull requests are welcomed ;-)
+
+
+# How to use this image
+
+## Start a postgres instance
+
+	docker run --name some-postgres -e POSTGRES_PASSWORD=mysecretpassword -d postgres
+
+This image includes `EXPOSE 5432` (the postgres port), so standard container linking will make it automatically available to the linked containers. The default `postgres` user and database are created in the entrypoint with `initdb`.
+
+> The postgres database is a default database meant for use by users, utilities and third party applications.  
+> [postgresql.org/docs](http://www.postgresql.org/docs/9.3/interactive/app-initdb.html)
+
+## Start LedgerSMB
+
+	docker run --name myledger --link some-postgres:postgres -d ledgersmb/ledgersmb
+
+## Set up LedgerSMB
+
+Visit http://myledger:5762/setup.pl (you can forward port 5762 to the host machine, or lookup the IP address for the "myledger" container if running on localhost)
+
+Log in with the "postgres" user and the password you set when starting up the Postgres container, and provide the name of a company database you want to create.
+
+Once you have completed the setup, you have a fully functional LedgerSMB instance running!
+
+Visit http://myledger:5762/login.pl to log in and get started.
+
+# Updating the LedgerSMB container
+
+No persistant data is stored in the LedgerSMB container. All LedgerSMB data is stored in Postgres, so you can stop/destroy/run a new LedgerSMB container, and as long as you link it to the Postgres database, you should be able to pick up where you left off.
+
+# Environment Variables
+
+The LedgerSMB image uses several environment variables which are easy to miss. While none of the variables are required, they may significantly aid you in using the image.
+
+### `POSTGRES_HOST` = 'postgres'
+
+This environment variable is used to specify the hostname of the Postgres server. The default is "postgres", which will find the container linked in.
+
+If you set this to another hostname, LedgerSMB will attempt to connect to that hostname instead.
+
+## `POSTGRES_PORT` = 5432
+
+Port to connect to Postgres on. Use to connect to a Postgres server running on an alternate port.
+
+## `DEFAULT_DB` = lsmb
+
+Set this if you want to automatically log in to a particular LSMB database.
+
+### `SSMTP_ROOT` `SSMTP_MAILHUB` `SSMTP_HOSTNAME` `SSMTP_USE_STARTTLS` `SSMTP_AUTH_USER` `SSMTP_AUTH_PASS` `SSMTP_METHOD` `SSMTP_FROMLINE_OVERRIDE`
+
+These variables are used to set outgoing SMTP defaults. To set the outgoing email address, set SSMTP_ROOT, and SSMTP_HOSTNAME at a minimum -- SSMTP_MAILHUB defaults to the default docker0 interface, so if your host is already configured to relay mail, this should relay successfully with only those two set.
+
+Use the other environment variables to relay mail through another host.
+
+# Troubleshooting/Developing
+
+You can connect to a running container using:
+
+> docker exec -ti myledger /bin/bash
+
+... this will give you a shell inside the container where you can inspect/troubleshoot the installation.
+
+Currently the LedgerSMB installation is in /srv/ledgersmb, and the startup/config script is /usr/bin/start.sh.
+
+
+# Supported Docker versions
+
+This image is officially supported on Docker version 1.11.1.
+
+Support for older versions is provided on a best-effort basis.
+
+# User Feedback
+
+## Documentation
+
+This is a brand new effort, and we will be adding documentation to the http://ledgersmb.org site when we get a chance.
+
+## Issues
+
+If you have any problems with or questions about this image or LedgerSMB, please contact us on the [mailing list](http://ledgersmb.org/topic/support/mailing-lists-rss-and-nntp-feeds) or through a [GitHub issue](https://github.com/ledgersmb/ledgersmb-docker/issues).
+
+You can also reach some of the official LedgerSMB maintainers via the `#ledgersmb` IRC channel on [Freenode](https://freenode.net), or on the bridged [Matrix](https://matrix.org) room in [#ledgersmb:matrix.org](https://matrix.to/#/#ledgersmb:matrix.org). The [Vector.im](https://vector.im/beta/#/room/#ledgersmb:matrix.org) Matrix client is highly recommended.
+
+
+## Contributing
+
+You are invited to contribute new features, fixes, or updates, large or small; we are always thrilled to receive pull requests, and do our best to process them as fast as we can.

--- a/ledgersmb-dev-perl-5.10/start.sh
+++ b/ledgersmb-dev-perl-5.10/start.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+update_ssmtp.sh
+cd /srv/ledgersmb
+
+if [[ ! -f ledgersmb.conf ]]; then
+  cp conf/ledgersmb.conf.default ledgersmb.conf
+  sed -i \
+    -e "s/\(cache_templates = \).*\$/cache_templates = 1/g" \
+    -e "s/\(host = \).*\$/\1$POSTGRES_HOST/g" \
+    -e "s/\(port = \).*\$/\1$POSTGRES_PORT/g" \
+    -e "s/\(default_db = \).*\$/\1$DEFAULT_DB/g" \
+    -e "s%\(sendmail   = \).*%\1/usr/sbin/ssmtp%g" \
+    /srv/ledgersmb/ledgersmb.conf
+fi
+
+# Currently unmaintained/untested
+# if [ ! -z ${CREATE_DATABASE+x} ]; then
+#   perl tools/dbsetup.pl --company $CREATE_DATABASE \
+#   --host $POSTGRES_HOST \
+#   --postgres_password "$POSTGRES_PASS"
+#fi
+
+# start ledgersmb
+exec starman --port 5762 --preload-app tools/starman.psgi

--- a/ledgersmb-dev-perl-5.10/update_ssmtp.sh
+++ b/ledgersmb-dev-perl-5.10/update_ssmtp.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+ConfiguredComment='# install script update_ssmtp.sh has configured ssmtp'
+grep -qc "$ConfiguredComment" /etc/ssmtp.conf && {
+    echo "smtp configured."
+    exit
+}
+
+sed -i \
+    -e "s/\(root=\).*\$/\1$SSMTP_ROOT/g" \
+    -e "s/\(mailhub=\).*\$/\1$SSMTP_MAILHUB/g" \
+    -e "s/\(hostname=\).*\$/\1$SSMTP_HOSTNAME/g" \
+    /etc/ssmtp/ssmtp.conf
+[ -z "$SSMTP_USE_STARTTLS" ] || echo "UseSTARTTLS=$SSMTP_USE_STARTTLS" >> /etc/ssmtp/ssmtp.conf
+[ -z "$SSMTP_AUTH_USER" ] || echo "AuthUser=$SSMTP_AUTH_USER" >> /etc/ssmtp/ssmtp.conf
+[ -z "$SSMTP_AUTH_PASS" ] || echo "AuthPass=$SSMTP_AUTH_PASS" >> /etc/ssmtp/ssmtp.conf
+[ -z "$SSMTP_AUTH_METHOD" ] || echo "AuthMethod=$SSMTP_AUTH_METHOD" >> /etc/ssmtp/ssmtp.conf
+[ -z "$SSMTP_FROMLINE_OVERRIDE" ] || echo "FromLineOverride=$SSMTP_FROMLINE_OVERRIDE" >> /etc/ssmtp/ssmtp.conf
+echo "$ConfiguredComment" >> /etc/ssmtp/ssmtp.conf

--- a/ledgersmb-dev-perl-5.12/Dockerfile
+++ b/ledgersmb-dev-perl-5.12/Dockerfile
@@ -1,0 +1,94 @@
+FROM perl:5.12
+MAINTAINER  Nick Prater nick@npbroadcast.com
+
+# ledgersmb development and test container created
+# from official perl images.
+
+# Dockerfile based on official ledgersmb/ledgersmb-dev-lsmb
+
+# No point installing perl libraries via apt-get as we're
+# using the official perl container, which doesn't use the
+# debian system libraries.
+#
+# gcc, cpanminus, git are already installed in the base perl image
+
+RUN echo -n "APT::Install-Recommends \"0\";\nAPT::Install-Suggests \"0\";\n" \
+       >> /etc/apt/apt.conf && \
+  DEBIAN_FRONTEND=noninteractive apt-get update && \
+  DEBIAN_FRONTEND=noninteractive apt-get -y install curl ca-certificates \
+                                            gnupg2 && \
+  curl -L https://deb.nodesource.com/setup_6.x -o ./setup && \
+  bash ./setup && rm ./setup && \
+  DEBIAN_FRONTEND=noninteractive apt-get update && \
+  DEBIAN_FRONTEND=noninteractive apt-get -y install \
+    postgresql-client \
+    texlive-latex-recommended \
+    texlive-xetex \
+    ssmtp \
+    nodejs lsb-release \
+    gettext procps  \
+  python-pip python-urllib3 python-six && \
+  pip install transifex-client && \
+  npm install -g uglify-js@">=2.0 <3.0"
+
+# 1.5 additional dependency install:
+#    JRE is for running the dojo build process using ClosureCompiler
+RUN DEBIAN_FRONTEND=noninteractive apt-get -y install \
+      default-jre-headless
+
+# Build time variables
+ENV NODE_PATH /usr/local/lib/node_modules
+ARG CACHEBUST
+
+# Install LedgerSMB
+RUN cd /srv && mkdir ledgersmb && cd ledgersmb && \
+  wget https://github.com/ledgersmb/LedgerSMB/raw/1.5/cpanfile && \
+  cpanm --quiet --notest \
+    --with-develop \
+    --with-feature=starman \
+    --with-feature=latex-pdf-images \
+    --with-feature=latex-pdf-ps \
+    --with-feature=openoffice \
+    --with-feature=edi \
+    --installdeps . && \
+  rm cpanfile && \
+  cpanm --quiet --notest Pod::ProjectDocs && \
+  rm -rf ~/.cpanm && \
+  cd .. && rm -rf ledgersmb && mkdir ledgersmb
+
+# Configure outgoing mail to use host, other run time variable defaults
+
+## sSMTP
+ENV SSMTP_ROOT ar@example.com
+ENV SSMTP_MAILHUB 172.17.0.1
+ENV SSMTP_HOSTNAME 172.17.0.1
+#ENV SSMTP_USE_STARTTLS
+#ENV SSMTP_AUTH_USER
+#ENV SSMTP_AUTH_PASS
+ENV SSMTP_FROMLINE_OVERRIDE YES
+#ENV SSMTP_AUTH_METHOD
+
+ENV POSTGRES_HOST postgres
+ENV POSTGRES_PORT 5432
+ENV DEFAULT_DB lsmb
+
+COPY start.sh /usr/local/bin/start.sh
+COPY update_ssmtp.sh /usr/local/bin/update_ssmtp.sh
+
+RUN chown www-data /etc/ssmtp /etc/ssmtp/ssmtp.conf && \
+  chmod +x /usr/local/bin/update_ssmtp.sh /usr/local/bin/start.sh && \
+  mkdir -p /var/www
+
+# Work around an aufs bug related to directory permissions:
+RUN mkdir -p /tmp && \
+  chmod 1777 /tmp
+
+# Internal Port Expose
+EXPOSE 5762
+# If ledgersmb.conf does not exist, www-data user needs to be able to create it.
+RUN chown www-data /srv/ledgersmb
+USER www-data
+
+WORKDIR /srv/ledgersmb
+
+CMD ["start.sh"]

--- a/ledgersmb-dev-perl-5.12/README.md
+++ b/ledgersmb-dev-perl-5.12/README.md
@@ -1,0 +1,111 @@
+# ledgersmb-docker
+Dockerfile for LedgerSMB Docker image
+
+This is a work in progress to make a docker image for running LedgerSMB. It should not be relied upon for production use!
+
+# Supported tags and respective `Dockerfile` links
+
+-	`dev-master` - Master branch from git, unstable
+- `1.5`, `1.5.x`, `latest` - Latest release tarball from 1.5 branch
+- `1.4`, `1.4.x` - Latest tagged release of git 1.4 branch
+
+
+# What is LedgerSMB?
+The LedgerSMB project's priority is to provide an extremely capable yet user-friendly accounting and ERP solution to small to mid-size businesses in all locales where there is interest in using the software. The focus on small to mid-size businesses offers an opportunity to provide a positive user experience in ways which are not present in larger organizations. LedgerSMB ought to strive to be both the ideal SMB accounting/ERP package and also a solution that a start-up will never outgrow. The goals mentioned above will help us provide this ideal solution by allowing us to focus both on technical architecture and on user experience.
+
+
+# How is this image designed to be used?
+
+This Docker image is built to provide a self-contained LedgerSMB instance. To be functional, you need to connect it to a running Postgres installation. The official Postgres container will work as is, if you link it to the LedgerSMB instance at startup, or you can provide environment variables to an appropriate Postgres server.
+
+LedgerSMB provides an http interface built on Starman out of the box, listening on port 5762. We do not recommend exposing this port, because we strongly recommend encrypting all connections using SSL/TLS. For production use, we recommend running a web server configured with SSL, such as Nginx or Apache, and proxying connections to LedgerSMB.
+
+The other services you will need to put this in production are an SMTP gateway (set environment variables for SSMTP at container startup) and optionally a local print server (e.g. CUPS) installation. The print service is not currently supported in this Docker image, but pull requests are welcomed ;-)
+
+
+# How to use this image
+
+## Start a postgres instance
+
+	docker run --name some-postgres -e POSTGRES_PASSWORD=mysecretpassword -d postgres
+
+This image includes `EXPOSE 5432` (the postgres port), so standard container linking will make it automatically available to the linked containers. The default `postgres` user and database are created in the entrypoint with `initdb`.
+
+> The postgres database is a default database meant for use by users, utilities and third party applications.  
+> [postgresql.org/docs](http://www.postgresql.org/docs/9.3/interactive/app-initdb.html)
+
+## Start LedgerSMB
+
+	docker run --name myledger --link some-postgres:postgres -d ledgersmb/ledgersmb
+
+## Set up LedgerSMB
+
+Visit http://myledger:5762/setup.pl (you can forward port 5762 to the host machine, or lookup the IP address for the "myledger" container if running on localhost)
+
+Log in with the "postgres" user and the password you set when starting up the Postgres container, and provide the name of a company database you want to create.
+
+Once you have completed the setup, you have a fully functional LedgerSMB instance running!
+
+Visit http://myledger:5762/login.pl to log in and get started.
+
+# Updating the LedgerSMB container
+
+No persistant data is stored in the LedgerSMB container. All LedgerSMB data is stored in Postgres, so you can stop/destroy/run a new LedgerSMB container, and as long as you link it to the Postgres database, you should be able to pick up where you left off.
+
+# Environment Variables
+
+The LedgerSMB image uses several environment variables which are easy to miss. While none of the variables are required, they may significantly aid you in using the image.
+
+### `POSTGRES_HOST` = 'postgres'
+
+This environment variable is used to specify the hostname of the Postgres server. The default is "postgres", which will find the container linked in.
+
+If you set this to another hostname, LedgerSMB will attempt to connect to that hostname instead.
+
+## `POSTGRES_PORT` = 5432
+
+Port to connect to Postgres on. Use to connect to a Postgres server running on an alternate port.
+
+## `DEFAULT_DB` = lsmb
+
+Set this if you want to automatically log in to a particular LSMB database.
+
+### `SSMTP_ROOT` `SSMTP_MAILHUB` `SSMTP_HOSTNAME` `SSMTP_USE_STARTTLS` `SSMTP_AUTH_USER` `SSMTP_AUTH_PASS` `SSMTP_METHOD` `SSMTP_FROMLINE_OVERRIDE`
+
+These variables are used to set outgoing SMTP defaults. To set the outgoing email address, set SSMTP_ROOT, and SSMTP_HOSTNAME at a minimum -- SSMTP_MAILHUB defaults to the default docker0 interface, so if your host is already configured to relay mail, this should relay successfully with only those two set.
+
+Use the other environment variables to relay mail through another host.
+
+# Troubleshooting/Developing
+
+You can connect to a running container using:
+
+> docker exec -ti myledger /bin/bash
+
+... this will give you a shell inside the container where you can inspect/troubleshoot the installation.
+
+Currently the LedgerSMB installation is in /srv/ledgersmb, and the startup/config script is /usr/bin/start.sh.
+
+
+# Supported Docker versions
+
+This image is officially supported on Docker version 1.11.1.
+
+Support for older versions is provided on a best-effort basis.
+
+# User Feedback
+
+## Documentation
+
+This is a brand new effort, and we will be adding documentation to the http://ledgersmb.org site when we get a chance.
+
+## Issues
+
+If you have any problems with or questions about this image or LedgerSMB, please contact us on the [mailing list](http://ledgersmb.org/topic/support/mailing-lists-rss-and-nntp-feeds) or through a [GitHub issue](https://github.com/ledgersmb/ledgersmb-docker/issues).
+
+You can also reach some of the official LedgerSMB maintainers via the `#ledgersmb` IRC channel on [Freenode](https://freenode.net), or on the bridged [Matrix](https://matrix.org) room in [#ledgersmb:matrix.org](https://matrix.to/#/#ledgersmb:matrix.org). The [Vector.im](https://vector.im/beta/#/room/#ledgersmb:matrix.org) Matrix client is highly recommended.
+
+
+## Contributing
+
+You are invited to contribute new features, fixes, or updates, large or small; we are always thrilled to receive pull requests, and do our best to process them as fast as we can.

--- a/ledgersmb-dev-perl-5.12/start.sh
+++ b/ledgersmb-dev-perl-5.12/start.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+update_ssmtp.sh
+cd /srv/ledgersmb
+
+if [[ ! -f ledgersmb.conf ]]; then
+  cp conf/ledgersmb.conf.default ledgersmb.conf
+  sed -i \
+    -e "s/\(cache_templates = \).*\$/cache_templates = 1/g" \
+    -e "s/\(host = \).*\$/\1$POSTGRES_HOST/g" \
+    -e "s/\(port = \).*\$/\1$POSTGRES_PORT/g" \
+    -e "s/\(default_db = \).*\$/\1$DEFAULT_DB/g" \
+    -e "s%\(sendmail   = \).*%\1/usr/sbin/ssmtp%g" \
+    /srv/ledgersmb/ledgersmb.conf
+fi
+
+# Currently unmaintained/untested
+# if [ ! -z ${CREATE_DATABASE+x} ]; then
+#   perl tools/dbsetup.pl --company $CREATE_DATABASE \
+#   --host $POSTGRES_HOST \
+#   --postgres_password "$POSTGRES_PASS"
+#fi
+
+# start ledgersmb
+exec starman --port 5762 --preload-app tools/starman.psgi

--- a/ledgersmb-dev-perl-5.12/update_ssmtp.sh
+++ b/ledgersmb-dev-perl-5.12/update_ssmtp.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+ConfiguredComment='# install script update_ssmtp.sh has configured ssmtp'
+grep -qc "$ConfiguredComment" /etc/ssmtp.conf && {
+    echo "smtp configured."
+    exit
+}
+
+sed -i \
+    -e "s/\(root=\).*\$/\1$SSMTP_ROOT/g" \
+    -e "s/\(mailhub=\).*\$/\1$SSMTP_MAILHUB/g" \
+    -e "s/\(hostname=\).*\$/\1$SSMTP_HOSTNAME/g" \
+    /etc/ssmtp/ssmtp.conf
+[ -z "$SSMTP_USE_STARTTLS" ] || echo "UseSTARTTLS=$SSMTP_USE_STARTTLS" >> /etc/ssmtp/ssmtp.conf
+[ -z "$SSMTP_AUTH_USER" ] || echo "AuthUser=$SSMTP_AUTH_USER" >> /etc/ssmtp/ssmtp.conf
+[ -z "$SSMTP_AUTH_PASS" ] || echo "AuthPass=$SSMTP_AUTH_PASS" >> /etc/ssmtp/ssmtp.conf
+[ -z "$SSMTP_AUTH_METHOD" ] || echo "AuthMethod=$SSMTP_AUTH_METHOD" >> /etc/ssmtp/ssmtp.conf
+[ -z "$SSMTP_FROMLINE_OVERRIDE" ] || echo "FromLineOverride=$SSMTP_FROMLINE_OVERRIDE" >> /etc/ssmtp/ssmtp.conf
+echo "$ConfiguredComment" >> /etc/ssmtp/ssmtp.conf

--- a/ledgersmb-dev-perl-5.14/Dockerfile
+++ b/ledgersmb-dev-perl-5.14/Dockerfile
@@ -1,0 +1,105 @@
+FROM perl:5.14
+MAINTAINER  Nick Prater nick@npbroadcast.com
+
+# ledgersmb development and test container created
+# from official perl images.
+
+# Dockerfile based on official ledgersmb/ledgersmb-dev-lsmb
+
+# No point installing perl libraries via apt-get as we're
+# using the official perl container, which doesn't use the
+# debian system libraries.
+#
+# gcc, cpanminus, git are already installed in the base perl image
+
+RUN echo -n "APT::Install-Recommends \"0\";\nAPT::Install-Suggests \"0\";\n" \
+       >> /etc/apt/apt.conf && \
+  DEBIAN_FRONTEND=noninteractive apt-get update && \
+  DEBIAN_FRONTEND=noninteractive apt-get -y install curl ca-certificates \
+                                            gnupg2 && \
+  curl -L https://deb.nodesource.com/setup_6.x -o ./setup && \
+  bash ./setup && rm ./setup && \
+  DEBIAN_FRONTEND=noninteractive apt-get update && \
+  DEBIAN_FRONTEND=noninteractive apt-get -y install \
+    postgresql-client \
+    texlive-latex-recommended \
+    texlive-xetex \
+    ssmtp \
+    nodejs lsb-release \
+    gettext procps  \
+  python-pip python-urllib3 python-six && \
+  pip install transifex-client && \
+  npm install -g uglify-js@">=2.0 <3.0"
+
+# 1.5 additional dependency install:
+#    JRE is for running the dojo build process using ClosureCompiler
+RUN DEBIAN_FRONTEND=noninteractive apt-get -y install \
+      default-jre-headless
+
+# Build time variables
+ENV NODE_PATH /usr/local/lib/node_modules
+ARG CACHEBUST
+
+# Install LedgerSMB
+RUN cd /srv && mkdir ledgersmb && cd ledgersmb && \
+  wget https://github.com/ledgersmb/LedgerSMB/raw/master/cpanfile && \
+  cpanm --quiet --notest \
+    --with-develop \
+    --with-feature=starman \
+    --with-feature=latex-pdf-images \
+    --with-feature=latex-pdf-ps \
+    --with-feature=openoffice \
+    --with-feature=xls \
+    --with-feature=edi \
+    --installdeps . && \
+  rm cpanfile && \
+  wget https://github.com/ledgersmb/LedgerSMB/raw/1.5/cpanfile && \
+  cpanm --quiet --notest \
+    --with-develop \
+    --with-feature=starman \
+    --with-feature=latex-pdf-images \
+    --with-feature=latex-pdf-ps \
+    --with-feature=openoffice \
+    --with-feature=edi \
+    --installdeps . && \
+  rm cpanfile && \
+  cpanm --quiet --notest Pod::ProjectDocs && \
+  rm -rf ~/.cpanm && \
+  cd .. && rm -rf ledgersmb && mkdir ledgersmb
+
+# Configure outgoing mail to use host, other run time variable defaults
+
+## sSMTP
+ENV SSMTP_ROOT ar@example.com
+ENV SSMTP_MAILHUB 172.17.0.1
+ENV SSMTP_HOSTNAME 172.17.0.1
+#ENV SSMTP_USE_STARTTLS
+#ENV SSMTP_AUTH_USER
+#ENV SSMTP_AUTH_PASS
+ENV SSMTP_FROMLINE_OVERRIDE YES
+#ENV SSMTP_AUTH_METHOD
+
+ENV POSTGRES_HOST postgres
+ENV POSTGRES_PORT 5432
+ENV DEFAULT_DB lsmb
+
+COPY start.sh /usr/local/bin/start.sh
+COPY update_ssmtp.sh /usr/local/bin/update_ssmtp.sh
+
+RUN chown www-data /etc/ssmtp /etc/ssmtp/ssmtp.conf && \
+  chmod +x /usr/local/bin/update_ssmtp.sh /usr/local/bin/start.sh && \
+  mkdir -p /var/www
+
+# Work around an aufs bug related to directory permissions:
+RUN mkdir -p /tmp && \
+  chmod 1777 /tmp
+
+# Internal Port Expose
+EXPOSE 5762
+# If ledgersmb.conf does not exist, www-data user needs to be able to create it.
+RUN chown www-data /srv/ledgersmb
+USER www-data
+
+WORKDIR /srv/ledgersmb
+
+CMD ["start.sh"]

--- a/ledgersmb-dev-perl-5.14/README.md
+++ b/ledgersmb-dev-perl-5.14/README.md
@@ -1,0 +1,111 @@
+# ledgersmb-docker
+Dockerfile for LedgerSMB Docker image
+
+This is a work in progress to make a docker image for running LedgerSMB. It should not be relied upon for production use!
+
+# Supported tags and respective `Dockerfile` links
+
+-	`dev-master` - Master branch from git, unstable
+- `1.5`, `1.5.x`, `latest` - Latest release tarball from 1.5 branch
+- `1.4`, `1.4.x` - Latest tagged release of git 1.4 branch
+
+
+# What is LedgerSMB?
+The LedgerSMB project's priority is to provide an extremely capable yet user-friendly accounting and ERP solution to small to mid-size businesses in all locales where there is interest in using the software. The focus on small to mid-size businesses offers an opportunity to provide a positive user experience in ways which are not present in larger organizations. LedgerSMB ought to strive to be both the ideal SMB accounting/ERP package and also a solution that a start-up will never outgrow. The goals mentioned above will help us provide this ideal solution by allowing us to focus both on technical architecture and on user experience.
+
+
+# How is this image designed to be used?
+
+This Docker image is built to provide a self-contained LedgerSMB instance. To be functional, you need to connect it to a running Postgres installation. The official Postgres container will work as is, if you link it to the LedgerSMB instance at startup, or you can provide environment variables to an appropriate Postgres server.
+
+LedgerSMB provides an http interface built on Starman out of the box, listening on port 5762. We do not recommend exposing this port, because we strongly recommend encrypting all connections using SSL/TLS. For production use, we recommend running a web server configured with SSL, such as Nginx or Apache, and proxying connections to LedgerSMB.
+
+The other services you will need to put this in production are an SMTP gateway (set environment variables for SSMTP at container startup) and optionally a local print server (e.g. CUPS) installation. The print service is not currently supported in this Docker image, but pull requests are welcomed ;-)
+
+
+# How to use this image
+
+## Start a postgres instance
+
+	docker run --name some-postgres -e POSTGRES_PASSWORD=mysecretpassword -d postgres
+
+This image includes `EXPOSE 5432` (the postgres port), so standard container linking will make it automatically available to the linked containers. The default `postgres` user and database are created in the entrypoint with `initdb`.
+
+> The postgres database is a default database meant for use by users, utilities and third party applications.  
+> [postgresql.org/docs](http://www.postgresql.org/docs/9.3/interactive/app-initdb.html)
+
+## Start LedgerSMB
+
+	docker run --name myledger --link some-postgres:postgres -d ledgersmb/ledgersmb
+
+## Set up LedgerSMB
+
+Visit http://myledger:5762/setup.pl (you can forward port 5762 to the host machine, or lookup the IP address for the "myledger" container if running on localhost)
+
+Log in with the "postgres" user and the password you set when starting up the Postgres container, and provide the name of a company database you want to create.
+
+Once you have completed the setup, you have a fully functional LedgerSMB instance running!
+
+Visit http://myledger:5762/login.pl to log in and get started.
+
+# Updating the LedgerSMB container
+
+No persistant data is stored in the LedgerSMB container. All LedgerSMB data is stored in Postgres, so you can stop/destroy/run a new LedgerSMB container, and as long as you link it to the Postgres database, you should be able to pick up where you left off.
+
+# Environment Variables
+
+The LedgerSMB image uses several environment variables which are easy to miss. While none of the variables are required, they may significantly aid you in using the image.
+
+### `POSTGRES_HOST` = 'postgres'
+
+This environment variable is used to specify the hostname of the Postgres server. The default is "postgres", which will find the container linked in.
+
+If you set this to another hostname, LedgerSMB will attempt to connect to that hostname instead.
+
+## `POSTGRES_PORT` = 5432
+
+Port to connect to Postgres on. Use to connect to a Postgres server running on an alternate port.
+
+## `DEFAULT_DB` = lsmb
+
+Set this if you want to automatically log in to a particular LSMB database.
+
+### `SSMTP_ROOT` `SSMTP_MAILHUB` `SSMTP_HOSTNAME` `SSMTP_USE_STARTTLS` `SSMTP_AUTH_USER` `SSMTP_AUTH_PASS` `SSMTP_METHOD` `SSMTP_FROMLINE_OVERRIDE`
+
+These variables are used to set outgoing SMTP defaults. To set the outgoing email address, set SSMTP_ROOT, and SSMTP_HOSTNAME at a minimum -- SSMTP_MAILHUB defaults to the default docker0 interface, so if your host is already configured to relay mail, this should relay successfully with only those two set.
+
+Use the other environment variables to relay mail through another host.
+
+# Troubleshooting/Developing
+
+You can connect to a running container using:
+
+> docker exec -ti myledger /bin/bash
+
+... this will give you a shell inside the container where you can inspect/troubleshoot the installation.
+
+Currently the LedgerSMB installation is in /srv/ledgersmb, and the startup/config script is /usr/bin/start.sh.
+
+
+# Supported Docker versions
+
+This image is officially supported on Docker version 1.11.1.
+
+Support for older versions is provided on a best-effort basis.
+
+# User Feedback
+
+## Documentation
+
+This is a brand new effort, and we will be adding documentation to the http://ledgersmb.org site when we get a chance.
+
+## Issues
+
+If you have any problems with or questions about this image or LedgerSMB, please contact us on the [mailing list](http://ledgersmb.org/topic/support/mailing-lists-rss-and-nntp-feeds) or through a [GitHub issue](https://github.com/ledgersmb/ledgersmb-docker/issues).
+
+You can also reach some of the official LedgerSMB maintainers via the `#ledgersmb` IRC channel on [Freenode](https://freenode.net), or on the bridged [Matrix](https://matrix.org) room in [#ledgersmb:matrix.org](https://matrix.to/#/#ledgersmb:matrix.org). The [Vector.im](https://vector.im/beta/#/room/#ledgersmb:matrix.org) Matrix client is highly recommended.
+
+
+## Contributing
+
+You are invited to contribute new features, fixes, or updates, large or small; we are always thrilled to receive pull requests, and do our best to process them as fast as we can.

--- a/ledgersmb-dev-perl-5.14/start.sh
+++ b/ledgersmb-dev-perl-5.14/start.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+update_ssmtp.sh
+cd /srv/ledgersmb
+
+if [[ ! -f ledgersmb.conf ]]; then
+  cp conf/ledgersmb.conf.default ledgersmb.conf
+  sed -i \
+    -e "s/\(cache_templates = \).*\$/cache_templates = 1/g" \
+    -e "s/\(host = \).*\$/\1$POSTGRES_HOST/g" \
+    -e "s/\(port = \).*\$/\1$POSTGRES_PORT/g" \
+    -e "s/\(default_db = \).*\$/\1$DEFAULT_DB/g" \
+    -e "s%\(sendmail   = \).*%\1/usr/sbin/ssmtp%g" \
+    /srv/ledgersmb/ledgersmb.conf
+fi
+
+# Currently unmaintained/untested
+# if [ ! -z ${CREATE_DATABASE+x} ]; then
+#   perl tools/dbsetup.pl --company $CREATE_DATABASE \
+#   --host $POSTGRES_HOST \
+#   --postgres_password "$POSTGRES_PASS"
+#fi
+
+# start ledgersmb
+exec starman --port 5762 --preload-app tools/starman.psgi

--- a/ledgersmb-dev-perl-5.14/update_ssmtp.sh
+++ b/ledgersmb-dev-perl-5.14/update_ssmtp.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+ConfiguredComment='# install script update_ssmtp.sh has configured ssmtp'
+grep -qc "$ConfiguredComment" /etc/ssmtp.conf && {
+    echo "smtp configured."
+    exit
+}
+
+sed -i \
+    -e "s/\(root=\).*\$/\1$SSMTP_ROOT/g" \
+    -e "s/\(mailhub=\).*\$/\1$SSMTP_MAILHUB/g" \
+    -e "s/\(hostname=\).*\$/\1$SSMTP_HOSTNAME/g" \
+    /etc/ssmtp/ssmtp.conf
+[ -z "$SSMTP_USE_STARTTLS" ] || echo "UseSTARTTLS=$SSMTP_USE_STARTTLS" >> /etc/ssmtp/ssmtp.conf
+[ -z "$SSMTP_AUTH_USER" ] || echo "AuthUser=$SSMTP_AUTH_USER" >> /etc/ssmtp/ssmtp.conf
+[ -z "$SSMTP_AUTH_PASS" ] || echo "AuthPass=$SSMTP_AUTH_PASS" >> /etc/ssmtp/ssmtp.conf
+[ -z "$SSMTP_AUTH_METHOD" ] || echo "AuthMethod=$SSMTP_AUTH_METHOD" >> /etc/ssmtp/ssmtp.conf
+[ -z "$SSMTP_FROMLINE_OVERRIDE" ] || echo "FromLineOverride=$SSMTP_FROMLINE_OVERRIDE" >> /etc/ssmtp/ssmtp.conf
+echo "$ConfiguredComment" >> /etc/ssmtp/ssmtp.conf

--- a/ledgersmb-dev-perl-5.16/Dockerfile
+++ b/ledgersmb-dev-perl-5.16/Dockerfile
@@ -1,0 +1,105 @@
+FROM perl:5.16
+MAINTAINER  Nick Prater nick@npbroadcast.com
+
+# ledgersmb development and test container created
+# from official perl images.
+
+# Dockerfile based on official ledgersmb/ledgersmb-dev-lsmb
+
+# No point installing perl libraries via apt-get as we're
+# using the official perl container, which doesn't use the
+# debian system libraries.
+#
+# gcc, cpanminus, git are already installed in the base perl image
+
+RUN echo -n "APT::Install-Recommends \"0\";\nAPT::Install-Suggests \"0\";\n" \
+       >> /etc/apt/apt.conf && \
+  DEBIAN_FRONTEND=noninteractive apt-get update && \
+  DEBIAN_FRONTEND=noninteractive apt-get -y install curl ca-certificates \
+                                            gnupg2 && \
+  curl -L https://deb.nodesource.com/setup_6.x -o ./setup && \
+  bash ./setup && rm ./setup && \
+  DEBIAN_FRONTEND=noninteractive apt-get update && \
+  DEBIAN_FRONTEND=noninteractive apt-get -y install \
+    postgresql-client \
+    texlive-latex-recommended \
+    texlive-xetex \
+    ssmtp \
+    nodejs lsb-release \
+    gettext procps  \
+  python-pip python-urllib3 python-six && \
+  pip install transifex-client && \
+  npm install -g uglify-js@">=2.0 <3.0"
+
+# 1.5 additional dependency install:
+#    JRE is for running the dojo build process using ClosureCompiler
+RUN DEBIAN_FRONTEND=noninteractive apt-get -y install \
+      default-jre-headless
+
+# Build time variables
+ENV NODE_PATH /usr/local/lib/node_modules
+ARG CACHEBUST
+
+# Install LedgerSMB
+RUN cd /srv && mkdir ledgersmb && cd ledgersmb && \
+  wget https://github.com/ledgersmb/LedgerSMB/raw/master/cpanfile && \
+  cpanm --quiet --notest \
+    --with-develop \
+    --with-feature=starman \
+    --with-feature=latex-pdf-images \
+    --with-feature=latex-pdf-ps \
+    --with-feature=openoffice \
+    --with-feature=xls \
+    --with-feature=edi \
+    --installdeps . && \
+  rm cpanfile && \
+  wget https://github.com/ledgersmb/LedgerSMB/raw/1.5/cpanfile && \
+  cpanm --quiet --notest \
+    --with-develop \
+    --with-feature=starman \
+    --with-feature=latex-pdf-images \
+    --with-feature=latex-pdf-ps \
+    --with-feature=openoffice \
+    --with-feature=edi \
+    --installdeps . && \
+  rm cpanfile && \
+  cpanm --quiet --notest Pod::ProjectDocs && \
+  rm -rf ~/.cpanm && \
+  cd .. && rm -rf ledgersmb && mkdir ledgersmb
+
+# Configure outgoing mail to use host, other run time variable defaults
+
+## sSMTP
+ENV SSMTP_ROOT ar@example.com
+ENV SSMTP_MAILHUB 172.17.0.1
+ENV SSMTP_HOSTNAME 172.17.0.1
+#ENV SSMTP_USE_STARTTLS
+#ENV SSMTP_AUTH_USER
+#ENV SSMTP_AUTH_PASS
+ENV SSMTP_FROMLINE_OVERRIDE YES
+#ENV SSMTP_AUTH_METHOD
+
+ENV POSTGRES_HOST postgres
+ENV POSTGRES_PORT 5432
+ENV DEFAULT_DB lsmb
+
+COPY start.sh /usr/local/bin/start.sh
+COPY update_ssmtp.sh /usr/local/bin/update_ssmtp.sh
+
+RUN chown www-data /etc/ssmtp /etc/ssmtp/ssmtp.conf && \
+  chmod +x /usr/local/bin/update_ssmtp.sh /usr/local/bin/start.sh && \
+  mkdir -p /var/www
+
+# Work around an aufs bug related to directory permissions:
+RUN mkdir -p /tmp && \
+  chmod 1777 /tmp
+
+# Internal Port Expose
+EXPOSE 5762
+# If ledgersmb.conf does not exist, www-data user needs to be able to create it.
+RUN chown www-data /srv/ledgersmb
+USER www-data
+
+WORKDIR /srv/ledgersmb
+
+CMD ["start.sh"]

--- a/ledgersmb-dev-perl-5.16/README.md
+++ b/ledgersmb-dev-perl-5.16/README.md
@@ -1,0 +1,111 @@
+# ledgersmb-docker
+Dockerfile for LedgerSMB Docker image
+
+This is a work in progress to make a docker image for running LedgerSMB. It should not be relied upon for production use!
+
+# Supported tags and respective `Dockerfile` links
+
+-	`dev-master` - Master branch from git, unstable
+- `1.5`, `1.5.x`, `latest` - Latest release tarball from 1.5 branch
+- `1.4`, `1.4.x` - Latest tagged release of git 1.4 branch
+
+
+# What is LedgerSMB?
+The LedgerSMB project's priority is to provide an extremely capable yet user-friendly accounting and ERP solution to small to mid-size businesses in all locales where there is interest in using the software. The focus on small to mid-size businesses offers an opportunity to provide a positive user experience in ways which are not present in larger organizations. LedgerSMB ought to strive to be both the ideal SMB accounting/ERP package and also a solution that a start-up will never outgrow. The goals mentioned above will help us provide this ideal solution by allowing us to focus both on technical architecture and on user experience.
+
+
+# How is this image designed to be used?
+
+This Docker image is built to provide a self-contained LedgerSMB instance. To be functional, you need to connect it to a running Postgres installation. The official Postgres container will work as is, if you link it to the LedgerSMB instance at startup, or you can provide environment variables to an appropriate Postgres server.
+
+LedgerSMB provides an http interface built on Starman out of the box, listening on port 5762. We do not recommend exposing this port, because we strongly recommend encrypting all connections using SSL/TLS. For production use, we recommend running a web server configured with SSL, such as Nginx or Apache, and proxying connections to LedgerSMB.
+
+The other services you will need to put this in production are an SMTP gateway (set environment variables for SSMTP at container startup) and optionally a local print server (e.g. CUPS) installation. The print service is not currently supported in this Docker image, but pull requests are welcomed ;-)
+
+
+# How to use this image
+
+## Start a postgres instance
+
+	docker run --name some-postgres -e POSTGRES_PASSWORD=mysecretpassword -d postgres
+
+This image includes `EXPOSE 5432` (the postgres port), so standard container linking will make it automatically available to the linked containers. The default `postgres` user and database are created in the entrypoint with `initdb`.
+
+> The postgres database is a default database meant for use by users, utilities and third party applications.  
+> [postgresql.org/docs](http://www.postgresql.org/docs/9.3/interactive/app-initdb.html)
+
+## Start LedgerSMB
+
+	docker run --name myledger --link some-postgres:postgres -d ledgersmb/ledgersmb
+
+## Set up LedgerSMB
+
+Visit http://myledger:5762/setup.pl (you can forward port 5762 to the host machine, or lookup the IP address for the "myledger" container if running on localhost)
+
+Log in with the "postgres" user and the password you set when starting up the Postgres container, and provide the name of a company database you want to create.
+
+Once you have completed the setup, you have a fully functional LedgerSMB instance running!
+
+Visit http://myledger:5762/login.pl to log in and get started.
+
+# Updating the LedgerSMB container
+
+No persistant data is stored in the LedgerSMB container. All LedgerSMB data is stored in Postgres, so you can stop/destroy/run a new LedgerSMB container, and as long as you link it to the Postgres database, you should be able to pick up where you left off.
+
+# Environment Variables
+
+The LedgerSMB image uses several environment variables which are easy to miss. While none of the variables are required, they may significantly aid you in using the image.
+
+### `POSTGRES_HOST` = 'postgres'
+
+This environment variable is used to specify the hostname of the Postgres server. The default is "postgres", which will find the container linked in.
+
+If you set this to another hostname, LedgerSMB will attempt to connect to that hostname instead.
+
+## `POSTGRES_PORT` = 5432
+
+Port to connect to Postgres on. Use to connect to a Postgres server running on an alternate port.
+
+## `DEFAULT_DB` = lsmb
+
+Set this if you want to automatically log in to a particular LSMB database.
+
+### `SSMTP_ROOT` `SSMTP_MAILHUB` `SSMTP_HOSTNAME` `SSMTP_USE_STARTTLS` `SSMTP_AUTH_USER` `SSMTP_AUTH_PASS` `SSMTP_METHOD` `SSMTP_FROMLINE_OVERRIDE`
+
+These variables are used to set outgoing SMTP defaults. To set the outgoing email address, set SSMTP_ROOT, and SSMTP_HOSTNAME at a minimum -- SSMTP_MAILHUB defaults to the default docker0 interface, so if your host is already configured to relay mail, this should relay successfully with only those two set.
+
+Use the other environment variables to relay mail through another host.
+
+# Troubleshooting/Developing
+
+You can connect to a running container using:
+
+> docker exec -ti myledger /bin/bash
+
+... this will give you a shell inside the container where you can inspect/troubleshoot the installation.
+
+Currently the LedgerSMB installation is in /srv/ledgersmb, and the startup/config script is /usr/bin/start.sh.
+
+
+# Supported Docker versions
+
+This image is officially supported on Docker version 1.11.1.
+
+Support for older versions is provided on a best-effort basis.
+
+# User Feedback
+
+## Documentation
+
+This is a brand new effort, and we will be adding documentation to the http://ledgersmb.org site when we get a chance.
+
+## Issues
+
+If you have any problems with or questions about this image or LedgerSMB, please contact us on the [mailing list](http://ledgersmb.org/topic/support/mailing-lists-rss-and-nntp-feeds) or through a [GitHub issue](https://github.com/ledgersmb/ledgersmb-docker/issues).
+
+You can also reach some of the official LedgerSMB maintainers via the `#ledgersmb` IRC channel on [Freenode](https://freenode.net), or on the bridged [Matrix](https://matrix.org) room in [#ledgersmb:matrix.org](https://matrix.to/#/#ledgersmb:matrix.org). The [Vector.im](https://vector.im/beta/#/room/#ledgersmb:matrix.org) Matrix client is highly recommended.
+
+
+## Contributing
+
+You are invited to contribute new features, fixes, or updates, large or small; we are always thrilled to receive pull requests, and do our best to process them as fast as we can.

--- a/ledgersmb-dev-perl-5.16/start.sh
+++ b/ledgersmb-dev-perl-5.16/start.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+update_ssmtp.sh
+cd /srv/ledgersmb
+
+if [[ ! -f ledgersmb.conf ]]; then
+  cp conf/ledgersmb.conf.default ledgersmb.conf
+  sed -i \
+    -e "s/\(cache_templates = \).*\$/cache_templates = 1/g" \
+    -e "s/\(host = \).*\$/\1$POSTGRES_HOST/g" \
+    -e "s/\(port = \).*\$/\1$POSTGRES_PORT/g" \
+    -e "s/\(default_db = \).*\$/\1$DEFAULT_DB/g" \
+    -e "s%\(sendmail   = \).*%\1/usr/sbin/ssmtp%g" \
+    /srv/ledgersmb/ledgersmb.conf
+fi
+
+# Currently unmaintained/untested
+# if [ ! -z ${CREATE_DATABASE+x} ]; then
+#   perl tools/dbsetup.pl --company $CREATE_DATABASE \
+#   --host $POSTGRES_HOST \
+#   --postgres_password "$POSTGRES_PASS"
+#fi
+
+# start ledgersmb
+exec starman --port 5762 --preload-app tools/starman.psgi

--- a/ledgersmb-dev-perl-5.16/update_ssmtp.sh
+++ b/ledgersmb-dev-perl-5.16/update_ssmtp.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+ConfiguredComment='# install script update_ssmtp.sh has configured ssmtp'
+grep -qc "$ConfiguredComment" /etc/ssmtp.conf && {
+    echo "smtp configured."
+    exit
+}
+
+sed -i \
+    -e "s/\(root=\).*\$/\1$SSMTP_ROOT/g" \
+    -e "s/\(mailhub=\).*\$/\1$SSMTP_MAILHUB/g" \
+    -e "s/\(hostname=\).*\$/\1$SSMTP_HOSTNAME/g" \
+    /etc/ssmtp/ssmtp.conf
+[ -z "$SSMTP_USE_STARTTLS" ] || echo "UseSTARTTLS=$SSMTP_USE_STARTTLS" >> /etc/ssmtp/ssmtp.conf
+[ -z "$SSMTP_AUTH_USER" ] || echo "AuthUser=$SSMTP_AUTH_USER" >> /etc/ssmtp/ssmtp.conf
+[ -z "$SSMTP_AUTH_PASS" ] || echo "AuthPass=$SSMTP_AUTH_PASS" >> /etc/ssmtp/ssmtp.conf
+[ -z "$SSMTP_AUTH_METHOD" ] || echo "AuthMethod=$SSMTP_AUTH_METHOD" >> /etc/ssmtp/ssmtp.conf
+[ -z "$SSMTP_FROMLINE_OVERRIDE" ] || echo "FromLineOverride=$SSMTP_FROMLINE_OVERRIDE" >> /etc/ssmtp/ssmtp.conf
+echo "$ConfiguredComment" >> /etc/ssmtp/ssmtp.conf

--- a/ledgersmb-dev-perl-5.18/Dockerfile
+++ b/ledgersmb-dev-perl-5.18/Dockerfile
@@ -1,0 +1,105 @@
+FROM perl:5.18
+MAINTAINER  Nick Prater nick@npbroadcast.com
+
+# ledgersmb development and test container created
+# from official perl images.
+
+# Dockerfile based on official ledgersmb/ledgersmb-dev-lsmb
+
+# No point installing perl libraries via apt-get as we're
+# using the official perl container, which doesn't use the
+# debian system libraries.
+#
+# gcc, cpanminus, git are already installed in the base perl image
+
+RUN echo -n "APT::Install-Recommends \"0\";\nAPT::Install-Suggests \"0\";\n" \
+       >> /etc/apt/apt.conf && \
+  DEBIAN_FRONTEND=noninteractive apt-get update && \
+  DEBIAN_FRONTEND=noninteractive apt-get -y install curl ca-certificates \
+                                            gnupg2 && \
+  curl -L https://deb.nodesource.com/setup_6.x -o ./setup && \
+  bash ./setup && rm ./setup && \
+  DEBIAN_FRONTEND=noninteractive apt-get update && \
+  DEBIAN_FRONTEND=noninteractive apt-get -y install \
+    postgresql-client \
+    texlive-latex-recommended \
+    texlive-xetex \
+    ssmtp \
+    nodejs lsb-release \
+    gettext procps  \
+  python-pip python-urllib3 python-six && \
+  pip install transifex-client && \
+  npm install -g uglify-js@">=2.0 <3.0"
+
+# 1.5 additional dependency install:
+#    JRE is for running the dojo build process using ClosureCompiler
+RUN DEBIAN_FRONTEND=noninteractive apt-get -y install \
+      default-jre-headless
+
+# Build time variables
+ENV NODE_PATH /usr/local/lib/node_modules
+ARG CACHEBUST
+
+# Install LedgerSMB
+RUN cd /srv && mkdir ledgersmb && cd ledgersmb && \
+  wget https://github.com/ledgersmb/LedgerSMB/raw/master/cpanfile && \
+  cpanm --quiet --notest \
+    --with-develop \
+    --with-feature=starman \
+    --with-feature=latex-pdf-images \
+    --with-feature=latex-pdf-ps \
+    --with-feature=openoffice \
+    --with-feature=xls \
+    --with-feature=edi \
+    --installdeps . && \
+  rm cpanfile && \
+  wget https://github.com/ledgersmb/LedgerSMB/raw/1.5/cpanfile && \
+  cpanm --quiet --notest \
+    --with-develop \
+    --with-feature=starman \
+    --with-feature=latex-pdf-images \
+    --with-feature=latex-pdf-ps \
+    --with-feature=openoffice \
+    --with-feature=edi \
+    --installdeps . && \
+  rm cpanfile && \
+  cpanm --quiet --notest Pod::ProjectDocs && \
+  rm -rf ~/.cpanm && \
+  cd .. && rm -rf ledgersmb && mkdir ledgersmb
+
+# Configure outgoing mail to use host, other run time variable defaults
+
+## sSMTP
+ENV SSMTP_ROOT ar@example.com
+ENV SSMTP_MAILHUB 172.17.0.1
+ENV SSMTP_HOSTNAME 172.17.0.1
+#ENV SSMTP_USE_STARTTLS
+#ENV SSMTP_AUTH_USER
+#ENV SSMTP_AUTH_PASS
+ENV SSMTP_FROMLINE_OVERRIDE YES
+#ENV SSMTP_AUTH_METHOD
+
+ENV POSTGRES_HOST postgres
+ENV POSTGRES_PORT 5432
+ENV DEFAULT_DB lsmb
+
+COPY start.sh /usr/local/bin/start.sh
+COPY update_ssmtp.sh /usr/local/bin/update_ssmtp.sh
+
+RUN chown www-data /etc/ssmtp /etc/ssmtp/ssmtp.conf && \
+  chmod +x /usr/local/bin/update_ssmtp.sh /usr/local/bin/start.sh && \
+  mkdir -p /var/www
+
+# Work around an aufs bug related to directory permissions:
+RUN mkdir -p /tmp && \
+  chmod 1777 /tmp
+
+# Internal Port Expose
+EXPOSE 5762
+# If ledgersmb.conf does not exist, www-data user needs to be able to create it.
+RUN chown www-data /srv/ledgersmb
+USER www-data
+
+WORKDIR /srv/ledgersmb
+
+CMD ["start.sh"]

--- a/ledgersmb-dev-perl-5.18/README.md
+++ b/ledgersmb-dev-perl-5.18/README.md
@@ -1,0 +1,111 @@
+# ledgersmb-docker
+Dockerfile for LedgerSMB Docker image
+
+This is a work in progress to make a docker image for running LedgerSMB. It should not be relied upon for production use!
+
+# Supported tags and respective `Dockerfile` links
+
+-	`dev-master` - Master branch from git, unstable
+- `1.5`, `1.5.x`, `latest` - Latest release tarball from 1.5 branch
+- `1.4`, `1.4.x` - Latest tagged release of git 1.4 branch
+
+
+# What is LedgerSMB?
+The LedgerSMB project's priority is to provide an extremely capable yet user-friendly accounting and ERP solution to small to mid-size businesses in all locales where there is interest in using the software. The focus on small to mid-size businesses offers an opportunity to provide a positive user experience in ways which are not present in larger organizations. LedgerSMB ought to strive to be both the ideal SMB accounting/ERP package and also a solution that a start-up will never outgrow. The goals mentioned above will help us provide this ideal solution by allowing us to focus both on technical architecture and on user experience.
+
+
+# How is this image designed to be used?
+
+This Docker image is built to provide a self-contained LedgerSMB instance. To be functional, you need to connect it to a running Postgres installation. The official Postgres container will work as is, if you link it to the LedgerSMB instance at startup, or you can provide environment variables to an appropriate Postgres server.
+
+LedgerSMB provides an http interface built on Starman out of the box, listening on port 5762. We do not recommend exposing this port, because we strongly recommend encrypting all connections using SSL/TLS. For production use, we recommend running a web server configured with SSL, such as Nginx or Apache, and proxying connections to LedgerSMB.
+
+The other services you will need to put this in production are an SMTP gateway (set environment variables for SSMTP at container startup) and optionally a local print server (e.g. CUPS) installation. The print service is not currently supported in this Docker image, but pull requests are welcomed ;-)
+
+
+# How to use this image
+
+## Start a postgres instance
+
+	docker run --name some-postgres -e POSTGRES_PASSWORD=mysecretpassword -d postgres
+
+This image includes `EXPOSE 5432` (the postgres port), so standard container linking will make it automatically available to the linked containers. The default `postgres` user and database are created in the entrypoint with `initdb`.
+
+> The postgres database is a default database meant for use by users, utilities and third party applications.  
+> [postgresql.org/docs](http://www.postgresql.org/docs/9.3/interactive/app-initdb.html)
+
+## Start LedgerSMB
+
+	docker run --name myledger --link some-postgres:postgres -d ledgersmb/ledgersmb
+
+## Set up LedgerSMB
+
+Visit http://myledger:5762/setup.pl (you can forward port 5762 to the host machine, or lookup the IP address for the "myledger" container if running on localhost)
+
+Log in with the "postgres" user and the password you set when starting up the Postgres container, and provide the name of a company database you want to create.
+
+Once you have completed the setup, you have a fully functional LedgerSMB instance running!
+
+Visit http://myledger:5762/login.pl to log in and get started.
+
+# Updating the LedgerSMB container
+
+No persistant data is stored in the LedgerSMB container. All LedgerSMB data is stored in Postgres, so you can stop/destroy/run a new LedgerSMB container, and as long as you link it to the Postgres database, you should be able to pick up where you left off.
+
+# Environment Variables
+
+The LedgerSMB image uses several environment variables which are easy to miss. While none of the variables are required, they may significantly aid you in using the image.
+
+### `POSTGRES_HOST` = 'postgres'
+
+This environment variable is used to specify the hostname of the Postgres server. The default is "postgres", which will find the container linked in.
+
+If you set this to another hostname, LedgerSMB will attempt to connect to that hostname instead.
+
+## `POSTGRES_PORT` = 5432
+
+Port to connect to Postgres on. Use to connect to a Postgres server running on an alternate port.
+
+## `DEFAULT_DB` = lsmb
+
+Set this if you want to automatically log in to a particular LSMB database.
+
+### `SSMTP_ROOT` `SSMTP_MAILHUB` `SSMTP_HOSTNAME` `SSMTP_USE_STARTTLS` `SSMTP_AUTH_USER` `SSMTP_AUTH_PASS` `SSMTP_METHOD` `SSMTP_FROMLINE_OVERRIDE`
+
+These variables are used to set outgoing SMTP defaults. To set the outgoing email address, set SSMTP_ROOT, and SSMTP_HOSTNAME at a minimum -- SSMTP_MAILHUB defaults to the default docker0 interface, so if your host is already configured to relay mail, this should relay successfully with only those two set.
+
+Use the other environment variables to relay mail through another host.
+
+# Troubleshooting/Developing
+
+You can connect to a running container using:
+
+> docker exec -ti myledger /bin/bash
+
+... this will give you a shell inside the container where you can inspect/troubleshoot the installation.
+
+Currently the LedgerSMB installation is in /srv/ledgersmb, and the startup/config script is /usr/bin/start.sh.
+
+
+# Supported Docker versions
+
+This image is officially supported on Docker version 1.11.1.
+
+Support for older versions is provided on a best-effort basis.
+
+# User Feedback
+
+## Documentation
+
+This is a brand new effort, and we will be adding documentation to the http://ledgersmb.org site when we get a chance.
+
+## Issues
+
+If you have any problems with or questions about this image or LedgerSMB, please contact us on the [mailing list](http://ledgersmb.org/topic/support/mailing-lists-rss-and-nntp-feeds) or through a [GitHub issue](https://github.com/ledgersmb/ledgersmb-docker/issues).
+
+You can also reach some of the official LedgerSMB maintainers via the `#ledgersmb` IRC channel on [Freenode](https://freenode.net), or on the bridged [Matrix](https://matrix.org) room in [#ledgersmb:matrix.org](https://matrix.to/#/#ledgersmb:matrix.org). The [Vector.im](https://vector.im/beta/#/room/#ledgersmb:matrix.org) Matrix client is highly recommended.
+
+
+## Contributing
+
+You are invited to contribute new features, fixes, or updates, large or small; we are always thrilled to receive pull requests, and do our best to process them as fast as we can.

--- a/ledgersmb-dev-perl-5.18/start.sh
+++ b/ledgersmb-dev-perl-5.18/start.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+update_ssmtp.sh
+cd /srv/ledgersmb
+
+if [[ ! -f ledgersmb.conf ]]; then
+  cp conf/ledgersmb.conf.default ledgersmb.conf
+  sed -i \
+    -e "s/\(cache_templates = \).*\$/cache_templates = 1/g" \
+    -e "s/\(host = \).*\$/\1$POSTGRES_HOST/g" \
+    -e "s/\(port = \).*\$/\1$POSTGRES_PORT/g" \
+    -e "s/\(default_db = \).*\$/\1$DEFAULT_DB/g" \
+    -e "s%\(sendmail   = \).*%\1/usr/sbin/ssmtp%g" \
+    /srv/ledgersmb/ledgersmb.conf
+fi
+
+# Currently unmaintained/untested
+# if [ ! -z ${CREATE_DATABASE+x} ]; then
+#   perl tools/dbsetup.pl --company $CREATE_DATABASE \
+#   --host $POSTGRES_HOST \
+#   --postgres_password "$POSTGRES_PASS"
+#fi
+
+# start ledgersmb
+exec starman --port 5762 --preload-app tools/starman.psgi

--- a/ledgersmb-dev-perl-5.18/update_ssmtp.sh
+++ b/ledgersmb-dev-perl-5.18/update_ssmtp.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+ConfiguredComment='# install script update_ssmtp.sh has configured ssmtp'
+grep -qc "$ConfiguredComment" /etc/ssmtp.conf && {
+    echo "smtp configured."
+    exit
+}
+
+sed -i \
+    -e "s/\(root=\).*\$/\1$SSMTP_ROOT/g" \
+    -e "s/\(mailhub=\).*\$/\1$SSMTP_MAILHUB/g" \
+    -e "s/\(hostname=\).*\$/\1$SSMTP_HOSTNAME/g" \
+    /etc/ssmtp/ssmtp.conf
+[ -z "$SSMTP_USE_STARTTLS" ] || echo "UseSTARTTLS=$SSMTP_USE_STARTTLS" >> /etc/ssmtp/ssmtp.conf
+[ -z "$SSMTP_AUTH_USER" ] || echo "AuthUser=$SSMTP_AUTH_USER" >> /etc/ssmtp/ssmtp.conf
+[ -z "$SSMTP_AUTH_PASS" ] || echo "AuthPass=$SSMTP_AUTH_PASS" >> /etc/ssmtp/ssmtp.conf
+[ -z "$SSMTP_AUTH_METHOD" ] || echo "AuthMethod=$SSMTP_AUTH_METHOD" >> /etc/ssmtp/ssmtp.conf
+[ -z "$SSMTP_FROMLINE_OVERRIDE" ] || echo "FromLineOverride=$SSMTP_FROMLINE_OVERRIDE" >> /etc/ssmtp/ssmtp.conf
+echo "$ConfiguredComment" >> /etc/ssmtp/ssmtp.conf

--- a/ledgersmb-dev-perl-5.20/Dockerfile
+++ b/ledgersmb-dev-perl-5.20/Dockerfile
@@ -1,0 +1,105 @@
+FROM perl:5.20
+MAINTAINER  Nick Prater nick@npbroadcast.com
+
+# ledgersmb development and test container created
+# from official perl images.
+
+# Dockerfile based on official ledgersmb/ledgersmb-dev-lsmb
+
+# No point installing perl libraries via apt-get as we're
+# using the official perl container, which doesn't use the
+# debian system libraries.
+#
+# gcc, cpanminus, git are already installed in the base perl image
+
+RUN echo -n "APT::Install-Recommends \"0\";\nAPT::Install-Suggests \"0\";\n" \
+       >> /etc/apt/apt.conf && \
+  DEBIAN_FRONTEND=noninteractive apt-get update && \
+  DEBIAN_FRONTEND=noninteractive apt-get -y install curl ca-certificates \
+                                            gnupg2 && \
+  curl -L https://deb.nodesource.com/setup_6.x -o ./setup && \
+  bash ./setup && rm ./setup && \
+  DEBIAN_FRONTEND=noninteractive apt-get update && \
+  DEBIAN_FRONTEND=noninteractive apt-get -y install \
+    postgresql-client \
+    texlive-latex-recommended \
+    texlive-xetex \
+    ssmtp \
+    nodejs lsb-release \
+    gettext procps  \
+  python-pip python-urllib3 python-six && \
+  pip install transifex-client && \
+  npm install -g uglify-js@">=2.0 <3.0"
+
+# 1.5 additional dependency install:
+#    JRE is for running the dojo build process using ClosureCompiler
+RUN DEBIAN_FRONTEND=noninteractive apt-get -y install \
+      default-jre-headless
+
+# Build time variables
+ENV NODE_PATH /usr/local/lib/node_modules
+ARG CACHEBUST
+
+# Install LedgerSMB
+RUN cd /srv && mkdir ledgersmb && cd ledgersmb && \
+  wget https://github.com/ledgersmb/LedgerSMB/raw/master/cpanfile && \
+  cpanm --quiet --notest \
+    --with-develop \
+    --with-feature=starman \
+    --with-feature=latex-pdf-images \
+    --with-feature=latex-pdf-ps \
+    --with-feature=openoffice \
+    --with-feature=xls \
+    --with-feature=edi \
+    --installdeps . && \
+  rm cpanfile && \
+  wget https://github.com/ledgersmb/LedgerSMB/raw/1.5/cpanfile && \
+  cpanm --quiet --notest \
+    --with-develop \
+    --with-feature=starman \
+    --with-feature=latex-pdf-images \
+    --with-feature=latex-pdf-ps \
+    --with-feature=openoffice \
+    --with-feature=edi \
+    --installdeps . && \
+  rm cpanfile && \
+  cpanm --quiet --notest Pod::ProjectDocs && \
+  rm -rf ~/.cpanm && \
+  cd .. && rm -rf ledgersmb && mkdir ledgersmb
+
+# Configure outgoing mail to use host, other run time variable defaults
+
+## sSMTP
+ENV SSMTP_ROOT ar@example.com
+ENV SSMTP_MAILHUB 172.17.0.1
+ENV SSMTP_HOSTNAME 172.17.0.1
+#ENV SSMTP_USE_STARTTLS
+#ENV SSMTP_AUTH_USER
+#ENV SSMTP_AUTH_PASS
+ENV SSMTP_FROMLINE_OVERRIDE YES
+#ENV SSMTP_AUTH_METHOD
+
+ENV POSTGRES_HOST postgres
+ENV POSTGRES_PORT 5432
+ENV DEFAULT_DB lsmb
+
+COPY start.sh /usr/local/bin/start.sh
+COPY update_ssmtp.sh /usr/local/bin/update_ssmtp.sh
+
+RUN chown www-data /etc/ssmtp /etc/ssmtp/ssmtp.conf && \
+  chmod +x /usr/local/bin/update_ssmtp.sh /usr/local/bin/start.sh && \
+  mkdir -p /var/www
+
+# Work around an aufs bug related to directory permissions:
+RUN mkdir -p /tmp && \
+  chmod 1777 /tmp
+
+# Internal Port Expose
+EXPOSE 5762
+# If ledgersmb.conf does not exist, www-data user needs to be able to create it.
+RUN chown www-data /srv/ledgersmb
+USER www-data
+
+WORKDIR /srv/ledgersmb
+
+CMD ["start.sh"]

--- a/ledgersmb-dev-perl-5.20/README.md
+++ b/ledgersmb-dev-perl-5.20/README.md
@@ -1,0 +1,111 @@
+# ledgersmb-docker
+Dockerfile for LedgerSMB Docker image
+
+This is a work in progress to make a docker image for running LedgerSMB. It should not be relied upon for production use!
+
+# Supported tags and respective `Dockerfile` links
+
+-	`dev-master` - Master branch from git, unstable
+- `1.5`, `1.5.x`, `latest` - Latest release tarball from 1.5 branch
+- `1.4`, `1.4.x` - Latest tagged release of git 1.4 branch
+
+
+# What is LedgerSMB?
+The LedgerSMB project's priority is to provide an extremely capable yet user-friendly accounting and ERP solution to small to mid-size businesses in all locales where there is interest in using the software. The focus on small to mid-size businesses offers an opportunity to provide a positive user experience in ways which are not present in larger organizations. LedgerSMB ought to strive to be both the ideal SMB accounting/ERP package and also a solution that a start-up will never outgrow. The goals mentioned above will help us provide this ideal solution by allowing us to focus both on technical architecture and on user experience.
+
+
+# How is this image designed to be used?
+
+This Docker image is built to provide a self-contained LedgerSMB instance. To be functional, you need to connect it to a running Postgres installation. The official Postgres container will work as is, if you link it to the LedgerSMB instance at startup, or you can provide environment variables to an appropriate Postgres server.
+
+LedgerSMB provides an http interface built on Starman out of the box, listening on port 5762. We do not recommend exposing this port, because we strongly recommend encrypting all connections using SSL/TLS. For production use, we recommend running a web server configured with SSL, such as Nginx or Apache, and proxying connections to LedgerSMB.
+
+The other services you will need to put this in production are an SMTP gateway (set environment variables for SSMTP at container startup) and optionally a local print server (e.g. CUPS) installation. The print service is not currently supported in this Docker image, but pull requests are welcomed ;-)
+
+
+# How to use this image
+
+## Start a postgres instance
+
+	docker run --name some-postgres -e POSTGRES_PASSWORD=mysecretpassword -d postgres
+
+This image includes `EXPOSE 5432` (the postgres port), so standard container linking will make it automatically available to the linked containers. The default `postgres` user and database are created in the entrypoint with `initdb`.
+
+> The postgres database is a default database meant for use by users, utilities and third party applications.  
+> [postgresql.org/docs](http://www.postgresql.org/docs/9.3/interactive/app-initdb.html)
+
+## Start LedgerSMB
+
+	docker run --name myledger --link some-postgres:postgres -d ledgersmb/ledgersmb
+
+## Set up LedgerSMB
+
+Visit http://myledger:5762/setup.pl (you can forward port 5762 to the host machine, or lookup the IP address for the "myledger" container if running on localhost)
+
+Log in with the "postgres" user and the password you set when starting up the Postgres container, and provide the name of a company database you want to create.
+
+Once you have completed the setup, you have a fully functional LedgerSMB instance running!
+
+Visit http://myledger:5762/login.pl to log in and get started.
+
+# Updating the LedgerSMB container
+
+No persistant data is stored in the LedgerSMB container. All LedgerSMB data is stored in Postgres, so you can stop/destroy/run a new LedgerSMB container, and as long as you link it to the Postgres database, you should be able to pick up where you left off.
+
+# Environment Variables
+
+The LedgerSMB image uses several environment variables which are easy to miss. While none of the variables are required, they may significantly aid you in using the image.
+
+### `POSTGRES_HOST` = 'postgres'
+
+This environment variable is used to specify the hostname of the Postgres server. The default is "postgres", which will find the container linked in.
+
+If you set this to another hostname, LedgerSMB will attempt to connect to that hostname instead.
+
+## `POSTGRES_PORT` = 5432
+
+Port to connect to Postgres on. Use to connect to a Postgres server running on an alternate port.
+
+## `DEFAULT_DB` = lsmb
+
+Set this if you want to automatically log in to a particular LSMB database.
+
+### `SSMTP_ROOT` `SSMTP_MAILHUB` `SSMTP_HOSTNAME` `SSMTP_USE_STARTTLS` `SSMTP_AUTH_USER` `SSMTP_AUTH_PASS` `SSMTP_METHOD` `SSMTP_FROMLINE_OVERRIDE`
+
+These variables are used to set outgoing SMTP defaults. To set the outgoing email address, set SSMTP_ROOT, and SSMTP_HOSTNAME at a minimum -- SSMTP_MAILHUB defaults to the default docker0 interface, so if your host is already configured to relay mail, this should relay successfully with only those two set.
+
+Use the other environment variables to relay mail through another host.
+
+# Troubleshooting/Developing
+
+You can connect to a running container using:
+
+> docker exec -ti myledger /bin/bash
+
+... this will give you a shell inside the container where you can inspect/troubleshoot the installation.
+
+Currently the LedgerSMB installation is in /srv/ledgersmb, and the startup/config script is /usr/bin/start.sh.
+
+
+# Supported Docker versions
+
+This image is officially supported on Docker version 1.11.1.
+
+Support for older versions is provided on a best-effort basis.
+
+# User Feedback
+
+## Documentation
+
+This is a brand new effort, and we will be adding documentation to the http://ledgersmb.org site when we get a chance.
+
+## Issues
+
+If you have any problems with or questions about this image or LedgerSMB, please contact us on the [mailing list](http://ledgersmb.org/topic/support/mailing-lists-rss-and-nntp-feeds) or through a [GitHub issue](https://github.com/ledgersmb/ledgersmb-docker/issues).
+
+You can also reach some of the official LedgerSMB maintainers via the `#ledgersmb` IRC channel on [Freenode](https://freenode.net), or on the bridged [Matrix](https://matrix.org) room in [#ledgersmb:matrix.org](https://matrix.to/#/#ledgersmb:matrix.org). The [Vector.im](https://vector.im/beta/#/room/#ledgersmb:matrix.org) Matrix client is highly recommended.
+
+
+## Contributing
+
+You are invited to contribute new features, fixes, or updates, large or small; we are always thrilled to receive pull requests, and do our best to process them as fast as we can.

--- a/ledgersmb-dev-perl-5.20/start.sh
+++ b/ledgersmb-dev-perl-5.20/start.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+update_ssmtp.sh
+cd /srv/ledgersmb
+
+if [[ ! -f ledgersmb.conf ]]; then
+  cp conf/ledgersmb.conf.default ledgersmb.conf
+  sed -i \
+    -e "s/\(cache_templates = \).*\$/cache_templates = 1/g" \
+    -e "s/\(host = \).*\$/\1$POSTGRES_HOST/g" \
+    -e "s/\(port = \).*\$/\1$POSTGRES_PORT/g" \
+    -e "s/\(default_db = \).*\$/\1$DEFAULT_DB/g" \
+    -e "s%\(sendmail   = \).*%\1/usr/sbin/ssmtp%g" \
+    /srv/ledgersmb/ledgersmb.conf
+fi
+
+# Currently unmaintained/untested
+# if [ ! -z ${CREATE_DATABASE+x} ]; then
+#   perl tools/dbsetup.pl --company $CREATE_DATABASE \
+#   --host $POSTGRES_HOST \
+#   --postgres_password "$POSTGRES_PASS"
+#fi
+
+# start ledgersmb
+exec starman --port 5762 --preload-app tools/starman.psgi

--- a/ledgersmb-dev-perl-5.20/update_ssmtp.sh
+++ b/ledgersmb-dev-perl-5.20/update_ssmtp.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+ConfiguredComment='# install script update_ssmtp.sh has configured ssmtp'
+grep -qc "$ConfiguredComment" /etc/ssmtp.conf && {
+    echo "smtp configured."
+    exit
+}
+
+sed -i \
+    -e "s/\(root=\).*\$/\1$SSMTP_ROOT/g" \
+    -e "s/\(mailhub=\).*\$/\1$SSMTP_MAILHUB/g" \
+    -e "s/\(hostname=\).*\$/\1$SSMTP_HOSTNAME/g" \
+    /etc/ssmtp/ssmtp.conf
+[ -z "$SSMTP_USE_STARTTLS" ] || echo "UseSTARTTLS=$SSMTP_USE_STARTTLS" >> /etc/ssmtp/ssmtp.conf
+[ -z "$SSMTP_AUTH_USER" ] || echo "AuthUser=$SSMTP_AUTH_USER" >> /etc/ssmtp/ssmtp.conf
+[ -z "$SSMTP_AUTH_PASS" ] || echo "AuthPass=$SSMTP_AUTH_PASS" >> /etc/ssmtp/ssmtp.conf
+[ -z "$SSMTP_AUTH_METHOD" ] || echo "AuthMethod=$SSMTP_AUTH_METHOD" >> /etc/ssmtp/ssmtp.conf
+[ -z "$SSMTP_FROMLINE_OVERRIDE" ] || echo "FromLineOverride=$SSMTP_FROMLINE_OVERRIDE" >> /etc/ssmtp/ssmtp.conf
+echo "$ConfiguredComment" >> /etc/ssmtp/ssmtp.conf

--- a/ledgersmb-dev-perl-5.22/Dockerfile
+++ b/ledgersmb-dev-perl-5.22/Dockerfile
@@ -1,0 +1,105 @@
+FROM perl:5.22
+MAINTAINER  Nick Prater nick@npbroadcast.com
+
+# ledgersmb development and test container created
+# from official perl images.
+
+# Dockerfile based on official ledgersmb/ledgersmb-dev-lsmb
+
+# No point installing perl libraries via apt-get as we're
+# using the official perl container, which doesn't use the
+# debian system libraries.
+#
+# gcc, cpanminus, git are already installed in the base perl image
+
+RUN echo -n "APT::Install-Recommends \"0\";\nAPT::Install-Suggests \"0\";\n" \
+       >> /etc/apt/apt.conf && \
+  DEBIAN_FRONTEND=noninteractive apt-get update && \
+  DEBIAN_FRONTEND=noninteractive apt-get -y install curl ca-certificates \
+                                            gnupg2 && \
+  curl -L https://deb.nodesource.com/setup_6.x -o ./setup && \
+  bash ./setup && rm ./setup && \
+  DEBIAN_FRONTEND=noninteractive apt-get update && \
+  DEBIAN_FRONTEND=noninteractive apt-get -y install \
+    postgresql-client \
+    texlive-latex-recommended \
+    texlive-xetex \
+    ssmtp \
+    nodejs lsb-release \
+    gettext procps  \
+  python-pip python-urllib3 python-six && \
+  pip install transifex-client && \
+  npm install -g uglify-js@">=2.0 <3.0"
+
+# 1.5 additional dependency install:
+#    JRE is for running the dojo build process using ClosureCompiler
+RUN DEBIAN_FRONTEND=noninteractive apt-get -y install \
+      default-jre-headless
+
+# Build time variables
+ENV NODE_PATH /usr/local/lib/node_modules
+ARG CACHEBUST
+
+# Install LedgerSMB
+RUN cd /srv && mkdir ledgersmb && cd ledgersmb && \
+  wget https://github.com/ledgersmb/LedgerSMB/raw/master/cpanfile && \
+  cpanm --quiet --notest \
+    --with-develop \
+    --with-feature=starman \
+    --with-feature=latex-pdf-images \
+    --with-feature=latex-pdf-ps \
+    --with-feature=openoffice \
+    --with-feature=xls \
+    --with-feature=edi \
+    --installdeps . && \
+  rm cpanfile && \
+  wget https://github.com/ledgersmb/LedgerSMB/raw/1.5/cpanfile && \
+  cpanm --quiet --notest \
+    --with-develop \
+    --with-feature=starman \
+    --with-feature=latex-pdf-images \
+    --with-feature=latex-pdf-ps \
+    --with-feature=openoffice \
+    --with-feature=edi \
+    --installdeps . && \
+  rm cpanfile && \
+  cpanm --quiet --notest Pod::ProjectDocs && \
+  rm -rf ~/.cpanm && \
+  cd .. && rm -rf ledgersmb && mkdir ledgersmb
+
+# Configure outgoing mail to use host, other run time variable defaults
+
+## sSMTP
+ENV SSMTP_ROOT ar@example.com
+ENV SSMTP_MAILHUB 172.17.0.1
+ENV SSMTP_HOSTNAME 172.17.0.1
+#ENV SSMTP_USE_STARTTLS
+#ENV SSMTP_AUTH_USER
+#ENV SSMTP_AUTH_PASS
+ENV SSMTP_FROMLINE_OVERRIDE YES
+#ENV SSMTP_AUTH_METHOD
+
+ENV POSTGRES_HOST postgres
+ENV POSTGRES_PORT 5432
+ENV DEFAULT_DB lsmb
+
+COPY start.sh /usr/local/bin/start.sh
+COPY update_ssmtp.sh /usr/local/bin/update_ssmtp.sh
+
+RUN chown www-data /etc/ssmtp /etc/ssmtp/ssmtp.conf && \
+  chmod +x /usr/local/bin/update_ssmtp.sh /usr/local/bin/start.sh && \
+  mkdir -p /var/www
+
+# Work around an aufs bug related to directory permissions:
+RUN mkdir -p /tmp && \
+  chmod 1777 /tmp
+
+# Internal Port Expose
+EXPOSE 5762
+# If ledgersmb.conf does not exist, www-data user needs to be able to create it.
+RUN chown www-data /srv/ledgersmb
+USER www-data
+
+WORKDIR /srv/ledgersmb
+
+CMD ["start.sh"]

--- a/ledgersmb-dev-perl-5.22/README.md
+++ b/ledgersmb-dev-perl-5.22/README.md
@@ -1,0 +1,111 @@
+# ledgersmb-docker
+Dockerfile for LedgerSMB Docker image
+
+This is a work in progress to make a docker image for running LedgerSMB. It should not be relied upon for production use!
+
+# Supported tags and respective `Dockerfile` links
+
+-	`dev-master` - Master branch from git, unstable
+- `1.5`, `1.5.x`, `latest` - Latest release tarball from 1.5 branch
+- `1.4`, `1.4.x` - Latest tagged release of git 1.4 branch
+
+
+# What is LedgerSMB?
+The LedgerSMB project's priority is to provide an extremely capable yet user-friendly accounting and ERP solution to small to mid-size businesses in all locales where there is interest in using the software. The focus on small to mid-size businesses offers an opportunity to provide a positive user experience in ways which are not present in larger organizations. LedgerSMB ought to strive to be both the ideal SMB accounting/ERP package and also a solution that a start-up will never outgrow. The goals mentioned above will help us provide this ideal solution by allowing us to focus both on technical architecture and on user experience.
+
+
+# How is this image designed to be used?
+
+This Docker image is built to provide a self-contained LedgerSMB instance. To be functional, you need to connect it to a running Postgres installation. The official Postgres container will work as is, if you link it to the LedgerSMB instance at startup, or you can provide environment variables to an appropriate Postgres server.
+
+LedgerSMB provides an http interface built on Starman out of the box, listening on port 5762. We do not recommend exposing this port, because we strongly recommend encrypting all connections using SSL/TLS. For production use, we recommend running a web server configured with SSL, such as Nginx or Apache, and proxying connections to LedgerSMB.
+
+The other services you will need to put this in production are an SMTP gateway (set environment variables for SSMTP at container startup) and optionally a local print server (e.g. CUPS) installation. The print service is not currently supported in this Docker image, but pull requests are welcomed ;-)
+
+
+# How to use this image
+
+## Start a postgres instance
+
+	docker run --name some-postgres -e POSTGRES_PASSWORD=mysecretpassword -d postgres
+
+This image includes `EXPOSE 5432` (the postgres port), so standard container linking will make it automatically available to the linked containers. The default `postgres` user and database are created in the entrypoint with `initdb`.
+
+> The postgres database is a default database meant for use by users, utilities and third party applications.  
+> [postgresql.org/docs](http://www.postgresql.org/docs/9.3/interactive/app-initdb.html)
+
+## Start LedgerSMB
+
+	docker run --name myledger --link some-postgres:postgres -d ledgersmb/ledgersmb
+
+## Set up LedgerSMB
+
+Visit http://myledger:5762/setup.pl (you can forward port 5762 to the host machine, or lookup the IP address for the "myledger" container if running on localhost)
+
+Log in with the "postgres" user and the password you set when starting up the Postgres container, and provide the name of a company database you want to create.
+
+Once you have completed the setup, you have a fully functional LedgerSMB instance running!
+
+Visit http://myledger:5762/login.pl to log in and get started.
+
+# Updating the LedgerSMB container
+
+No persistant data is stored in the LedgerSMB container. All LedgerSMB data is stored in Postgres, so you can stop/destroy/run a new LedgerSMB container, and as long as you link it to the Postgres database, you should be able to pick up where you left off.
+
+# Environment Variables
+
+The LedgerSMB image uses several environment variables which are easy to miss. While none of the variables are required, they may significantly aid you in using the image.
+
+### `POSTGRES_HOST` = 'postgres'
+
+This environment variable is used to specify the hostname of the Postgres server. The default is "postgres", which will find the container linked in.
+
+If you set this to another hostname, LedgerSMB will attempt to connect to that hostname instead.
+
+## `POSTGRES_PORT` = 5432
+
+Port to connect to Postgres on. Use to connect to a Postgres server running on an alternate port.
+
+## `DEFAULT_DB` = lsmb
+
+Set this if you want to automatically log in to a particular LSMB database.
+
+### `SSMTP_ROOT` `SSMTP_MAILHUB` `SSMTP_HOSTNAME` `SSMTP_USE_STARTTLS` `SSMTP_AUTH_USER` `SSMTP_AUTH_PASS` `SSMTP_METHOD` `SSMTP_FROMLINE_OVERRIDE`
+
+These variables are used to set outgoing SMTP defaults. To set the outgoing email address, set SSMTP_ROOT, and SSMTP_HOSTNAME at a minimum -- SSMTP_MAILHUB defaults to the default docker0 interface, so if your host is already configured to relay mail, this should relay successfully with only those two set.
+
+Use the other environment variables to relay mail through another host.
+
+# Troubleshooting/Developing
+
+You can connect to a running container using:
+
+> docker exec -ti myledger /bin/bash
+
+... this will give you a shell inside the container where you can inspect/troubleshoot the installation.
+
+Currently the LedgerSMB installation is in /srv/ledgersmb, and the startup/config script is /usr/bin/start.sh.
+
+
+# Supported Docker versions
+
+This image is officially supported on Docker version 1.11.1.
+
+Support for older versions is provided on a best-effort basis.
+
+# User Feedback
+
+## Documentation
+
+This is a brand new effort, and we will be adding documentation to the http://ledgersmb.org site when we get a chance.
+
+## Issues
+
+If you have any problems with or questions about this image or LedgerSMB, please contact us on the [mailing list](http://ledgersmb.org/topic/support/mailing-lists-rss-and-nntp-feeds) or through a [GitHub issue](https://github.com/ledgersmb/ledgersmb-docker/issues).
+
+You can also reach some of the official LedgerSMB maintainers via the `#ledgersmb` IRC channel on [Freenode](https://freenode.net), or on the bridged [Matrix](https://matrix.org) room in [#ledgersmb:matrix.org](https://matrix.to/#/#ledgersmb:matrix.org). The [Vector.im](https://vector.im/beta/#/room/#ledgersmb:matrix.org) Matrix client is highly recommended.
+
+
+## Contributing
+
+You are invited to contribute new features, fixes, or updates, large or small; we are always thrilled to receive pull requests, and do our best to process them as fast as we can.

--- a/ledgersmb-dev-perl-5.22/start.sh
+++ b/ledgersmb-dev-perl-5.22/start.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+update_ssmtp.sh
+cd /srv/ledgersmb
+
+if [[ ! -f ledgersmb.conf ]]; then
+  cp conf/ledgersmb.conf.default ledgersmb.conf
+  sed -i \
+    -e "s/\(cache_templates = \).*\$/cache_templates = 1/g" \
+    -e "s/\(host = \).*\$/\1$POSTGRES_HOST/g" \
+    -e "s/\(port = \).*\$/\1$POSTGRES_PORT/g" \
+    -e "s/\(default_db = \).*\$/\1$DEFAULT_DB/g" \
+    -e "s%\(sendmail   = \).*%\1/usr/sbin/ssmtp%g" \
+    /srv/ledgersmb/ledgersmb.conf
+fi
+
+# Currently unmaintained/untested
+# if [ ! -z ${CREATE_DATABASE+x} ]; then
+#   perl tools/dbsetup.pl --company $CREATE_DATABASE \
+#   --host $POSTGRES_HOST \
+#   --postgres_password "$POSTGRES_PASS"
+#fi
+
+# start ledgersmb
+exec starman --port 5762 --preload-app tools/starman.psgi

--- a/ledgersmb-dev-perl-5.22/update_ssmtp.sh
+++ b/ledgersmb-dev-perl-5.22/update_ssmtp.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+ConfiguredComment='# install script update_ssmtp.sh has configured ssmtp'
+grep -qc "$ConfiguredComment" /etc/ssmtp.conf && {
+    echo "smtp configured."
+    exit
+}
+
+sed -i \
+    -e "s/\(root=\).*\$/\1$SSMTP_ROOT/g" \
+    -e "s/\(mailhub=\).*\$/\1$SSMTP_MAILHUB/g" \
+    -e "s/\(hostname=\).*\$/\1$SSMTP_HOSTNAME/g" \
+    /etc/ssmtp/ssmtp.conf
+[ -z "$SSMTP_USE_STARTTLS" ] || echo "UseSTARTTLS=$SSMTP_USE_STARTTLS" >> /etc/ssmtp/ssmtp.conf
+[ -z "$SSMTP_AUTH_USER" ] || echo "AuthUser=$SSMTP_AUTH_USER" >> /etc/ssmtp/ssmtp.conf
+[ -z "$SSMTP_AUTH_PASS" ] || echo "AuthPass=$SSMTP_AUTH_PASS" >> /etc/ssmtp/ssmtp.conf
+[ -z "$SSMTP_AUTH_METHOD" ] || echo "AuthMethod=$SSMTP_AUTH_METHOD" >> /etc/ssmtp/ssmtp.conf
+[ -z "$SSMTP_FROMLINE_OVERRIDE" ] || echo "FromLineOverride=$SSMTP_FROMLINE_OVERRIDE" >> /etc/ssmtp/ssmtp.conf
+echo "$ConfiguredComment" >> /etc/ssmtp/ssmtp.conf

--- a/ledgersmb-dev-perl-5.24/Dockerfile
+++ b/ledgersmb-dev-perl-5.24/Dockerfile
@@ -1,0 +1,105 @@
+FROM perl:5.24
+MAINTAINER  Nick Prater nick@npbroadcast.com
+
+# ledgersmb development and test container created
+# from official perl images.
+
+# Dockerfile based on official ledgersmb/ledgersmb-dev-lsmb
+
+# No point installing perl libraries via apt-get as we're
+# using the official perl container, which doesn't use the
+# debian system libraries.
+#
+# gcc, cpanminus, git are already installed in the base perl image
+
+RUN echo -n "APT::Install-Recommends \"0\";\nAPT::Install-Suggests \"0\";\n" \
+       >> /etc/apt/apt.conf && \
+  DEBIAN_FRONTEND=noninteractive apt-get update && \
+  DEBIAN_FRONTEND=noninteractive apt-get -y install curl ca-certificates \
+                                            gnupg2 && \
+  curl -L https://deb.nodesource.com/setup_6.x -o ./setup && \
+  bash ./setup && rm ./setup && \
+  DEBIAN_FRONTEND=noninteractive apt-get update && \
+  DEBIAN_FRONTEND=noninteractive apt-get -y install \
+    postgresql-client \
+    texlive-latex-recommended \
+    texlive-xetex \
+    ssmtp \
+    nodejs lsb-release \
+    gettext procps  \
+  python-pip python-urllib3 python-six && \
+  pip install transifex-client && \
+  npm install -g uglify-js@">=2.0 <3.0"
+
+# 1.5 additional dependency install:
+#    JRE is for running the dojo build process using ClosureCompiler
+RUN DEBIAN_FRONTEND=noninteractive apt-get -y install \
+      default-jre-headless
+
+# Build time variables
+ENV NODE_PATH /usr/local/lib/node_modules
+ARG CACHEBUST
+
+# Install LedgerSMB
+RUN cd /srv && mkdir ledgersmb && cd ledgersmb && \
+  wget https://github.com/ledgersmb/LedgerSMB/raw/master/cpanfile && \
+  cpanm --quiet --notest \
+    --with-develop \
+    --with-feature=starman \
+    --with-feature=latex-pdf-images \
+    --with-feature=latex-pdf-ps \
+    --with-feature=openoffice \
+    --with-feature=xls \
+    --with-feature=edi \
+    --installdeps . && \
+  rm cpanfile && \
+  wget https://github.com/ledgersmb/LedgerSMB/raw/1.5/cpanfile && \
+  cpanm --quiet --notest \
+    --with-develop \
+    --with-feature=starman \
+    --with-feature=latex-pdf-images \
+    --with-feature=latex-pdf-ps \
+    --with-feature=openoffice \
+    --with-feature=edi \
+    --installdeps . && \
+  rm cpanfile && \
+  cpanm --quiet --notest Pod::ProjectDocs && \
+  rm -rf ~/.cpanm && \
+  cd .. && rm -rf ledgersmb && mkdir ledgersmb
+
+# Configure outgoing mail to use host, other run time variable defaults
+
+## sSMTP
+ENV SSMTP_ROOT ar@example.com
+ENV SSMTP_MAILHUB 172.17.0.1
+ENV SSMTP_HOSTNAME 172.17.0.1
+#ENV SSMTP_USE_STARTTLS
+#ENV SSMTP_AUTH_USER
+#ENV SSMTP_AUTH_PASS
+ENV SSMTP_FROMLINE_OVERRIDE YES
+#ENV SSMTP_AUTH_METHOD
+
+ENV POSTGRES_HOST postgres
+ENV POSTGRES_PORT 5432
+ENV DEFAULT_DB lsmb
+
+COPY start.sh /usr/local/bin/start.sh
+COPY update_ssmtp.sh /usr/local/bin/update_ssmtp.sh
+
+RUN chown www-data /etc/ssmtp /etc/ssmtp/ssmtp.conf && \
+  chmod +x /usr/local/bin/update_ssmtp.sh /usr/local/bin/start.sh && \
+  mkdir -p /var/www
+
+# Work around an aufs bug related to directory permissions:
+RUN mkdir -p /tmp && \
+  chmod 1777 /tmp
+
+# Internal Port Expose
+EXPOSE 5762
+# If ledgersmb.conf does not exist, www-data user needs to be able to create it.
+RUN chown www-data /srv/ledgersmb
+USER www-data
+
+WORKDIR /srv/ledgersmb
+
+CMD ["start.sh"]

--- a/ledgersmb-dev-perl-5.24/README.md
+++ b/ledgersmb-dev-perl-5.24/README.md
@@ -1,0 +1,111 @@
+# ledgersmb-docker
+Dockerfile for LedgerSMB Docker image
+
+This is a work in progress to make a docker image for running LedgerSMB. It should not be relied upon for production use!
+
+# Supported tags and respective `Dockerfile` links
+
+-	`dev-master` - Master branch from git, unstable
+- `1.5`, `1.5.x`, `latest` - Latest release tarball from 1.5 branch
+- `1.4`, `1.4.x` - Latest tagged release of git 1.4 branch
+
+
+# What is LedgerSMB?
+The LedgerSMB project's priority is to provide an extremely capable yet user-friendly accounting and ERP solution to small to mid-size businesses in all locales where there is interest in using the software. The focus on small to mid-size businesses offers an opportunity to provide a positive user experience in ways which are not present in larger organizations. LedgerSMB ought to strive to be both the ideal SMB accounting/ERP package and also a solution that a start-up will never outgrow. The goals mentioned above will help us provide this ideal solution by allowing us to focus both on technical architecture and on user experience.
+
+
+# How is this image designed to be used?
+
+This Docker image is built to provide a self-contained LedgerSMB instance. To be functional, you need to connect it to a running Postgres installation. The official Postgres container will work as is, if you link it to the LedgerSMB instance at startup, or you can provide environment variables to an appropriate Postgres server.
+
+LedgerSMB provides an http interface built on Starman out of the box, listening on port 5762. We do not recommend exposing this port, because we strongly recommend encrypting all connections using SSL/TLS. For production use, we recommend running a web server configured with SSL, such as Nginx or Apache, and proxying connections to LedgerSMB.
+
+The other services you will need to put this in production are an SMTP gateway (set environment variables for SSMTP at container startup) and optionally a local print server (e.g. CUPS) installation. The print service is not currently supported in this Docker image, but pull requests are welcomed ;-)
+
+
+# How to use this image
+
+## Start a postgres instance
+
+	docker run --name some-postgres -e POSTGRES_PASSWORD=mysecretpassword -d postgres
+
+This image includes `EXPOSE 5432` (the postgres port), so standard container linking will make it automatically available to the linked containers. The default `postgres` user and database are created in the entrypoint with `initdb`.
+
+> The postgres database is a default database meant for use by users, utilities and third party applications.  
+> [postgresql.org/docs](http://www.postgresql.org/docs/9.3/interactive/app-initdb.html)
+
+## Start LedgerSMB
+
+	docker run --name myledger --link some-postgres:postgres -d ledgersmb/ledgersmb
+
+## Set up LedgerSMB
+
+Visit http://myledger:5762/setup.pl (you can forward port 5762 to the host machine, or lookup the IP address for the "myledger" container if running on localhost)
+
+Log in with the "postgres" user and the password you set when starting up the Postgres container, and provide the name of a company database you want to create.
+
+Once you have completed the setup, you have a fully functional LedgerSMB instance running!
+
+Visit http://myledger:5762/login.pl to log in and get started.
+
+# Updating the LedgerSMB container
+
+No persistant data is stored in the LedgerSMB container. All LedgerSMB data is stored in Postgres, so you can stop/destroy/run a new LedgerSMB container, and as long as you link it to the Postgres database, you should be able to pick up where you left off.
+
+# Environment Variables
+
+The LedgerSMB image uses several environment variables which are easy to miss. While none of the variables are required, they may significantly aid you in using the image.
+
+### `POSTGRES_HOST` = 'postgres'
+
+This environment variable is used to specify the hostname of the Postgres server. The default is "postgres", which will find the container linked in.
+
+If you set this to another hostname, LedgerSMB will attempt to connect to that hostname instead.
+
+## `POSTGRES_PORT` = 5432
+
+Port to connect to Postgres on. Use to connect to a Postgres server running on an alternate port.
+
+## `DEFAULT_DB` = lsmb
+
+Set this if you want to automatically log in to a particular LSMB database.
+
+### `SSMTP_ROOT` `SSMTP_MAILHUB` `SSMTP_HOSTNAME` `SSMTP_USE_STARTTLS` `SSMTP_AUTH_USER` `SSMTP_AUTH_PASS` `SSMTP_METHOD` `SSMTP_FROMLINE_OVERRIDE`
+
+These variables are used to set outgoing SMTP defaults. To set the outgoing email address, set SSMTP_ROOT, and SSMTP_HOSTNAME at a minimum -- SSMTP_MAILHUB defaults to the default docker0 interface, so if your host is already configured to relay mail, this should relay successfully with only those two set.
+
+Use the other environment variables to relay mail through another host.
+
+# Troubleshooting/Developing
+
+You can connect to a running container using:
+
+> docker exec -ti myledger /bin/bash
+
+... this will give you a shell inside the container where you can inspect/troubleshoot the installation.
+
+Currently the LedgerSMB installation is in /srv/ledgersmb, and the startup/config script is /usr/bin/start.sh.
+
+
+# Supported Docker versions
+
+This image is officially supported on Docker version 1.11.1.
+
+Support for older versions is provided on a best-effort basis.
+
+# User Feedback
+
+## Documentation
+
+This is a brand new effort, and we will be adding documentation to the http://ledgersmb.org site when we get a chance.
+
+## Issues
+
+If you have any problems with or questions about this image or LedgerSMB, please contact us on the [mailing list](http://ledgersmb.org/topic/support/mailing-lists-rss-and-nntp-feeds) or through a [GitHub issue](https://github.com/ledgersmb/ledgersmb-docker/issues).
+
+You can also reach some of the official LedgerSMB maintainers via the `#ledgersmb` IRC channel on [Freenode](https://freenode.net), or on the bridged [Matrix](https://matrix.org) room in [#ledgersmb:matrix.org](https://matrix.to/#/#ledgersmb:matrix.org). The [Vector.im](https://vector.im/beta/#/room/#ledgersmb:matrix.org) Matrix client is highly recommended.
+
+
+## Contributing
+
+You are invited to contribute new features, fixes, or updates, large or small; we are always thrilled to receive pull requests, and do our best to process them as fast as we can.

--- a/ledgersmb-dev-perl-5.24/start.sh
+++ b/ledgersmb-dev-perl-5.24/start.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+update_ssmtp.sh
+cd /srv/ledgersmb
+
+if [[ ! -f ledgersmb.conf ]]; then
+  cp conf/ledgersmb.conf.default ledgersmb.conf
+  sed -i \
+    -e "s/\(cache_templates = \).*\$/cache_templates = 1/g" \
+    -e "s/\(host = \).*\$/\1$POSTGRES_HOST/g" \
+    -e "s/\(port = \).*\$/\1$POSTGRES_PORT/g" \
+    -e "s/\(default_db = \).*\$/\1$DEFAULT_DB/g" \
+    -e "s%\(sendmail   = \).*%\1/usr/sbin/ssmtp%g" \
+    /srv/ledgersmb/ledgersmb.conf
+fi
+
+# Currently unmaintained/untested
+# if [ ! -z ${CREATE_DATABASE+x} ]; then
+#   perl tools/dbsetup.pl --company $CREATE_DATABASE \
+#   --host $POSTGRES_HOST \
+#   --postgres_password "$POSTGRES_PASS"
+#fi
+
+# start ledgersmb
+exec starman --port 5762 --preload-app tools/starman.psgi

--- a/ledgersmb-dev-perl-5.24/update_ssmtp.sh
+++ b/ledgersmb-dev-perl-5.24/update_ssmtp.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+ConfiguredComment='# install script update_ssmtp.sh has configured ssmtp'
+grep -qc "$ConfiguredComment" /etc/ssmtp.conf && {
+    echo "smtp configured."
+    exit
+}
+
+sed -i \
+    -e "s/\(root=\).*\$/\1$SSMTP_ROOT/g" \
+    -e "s/\(mailhub=\).*\$/\1$SSMTP_MAILHUB/g" \
+    -e "s/\(hostname=\).*\$/\1$SSMTP_HOSTNAME/g" \
+    /etc/ssmtp/ssmtp.conf
+[ -z "$SSMTP_USE_STARTTLS" ] || echo "UseSTARTTLS=$SSMTP_USE_STARTTLS" >> /etc/ssmtp/ssmtp.conf
+[ -z "$SSMTP_AUTH_USER" ] || echo "AuthUser=$SSMTP_AUTH_USER" >> /etc/ssmtp/ssmtp.conf
+[ -z "$SSMTP_AUTH_PASS" ] || echo "AuthPass=$SSMTP_AUTH_PASS" >> /etc/ssmtp/ssmtp.conf
+[ -z "$SSMTP_AUTH_METHOD" ] || echo "AuthMethod=$SSMTP_AUTH_METHOD" >> /etc/ssmtp/ssmtp.conf
+[ -z "$SSMTP_FROMLINE_OVERRIDE" ] || echo "FromLineOverride=$SSMTP_FROMLINE_OVERRIDE" >> /etc/ssmtp/ssmtp.conf
+echo "$ConfiguredComment" >> /etc/ssmtp/ssmtp.conf

--- a/ledgersmb-dev-perl-5.26/Dockerfile
+++ b/ledgersmb-dev-perl-5.26/Dockerfile
@@ -1,0 +1,105 @@
+FROM perl:5.26
+MAINTAINER  Nick Prater nick@npbroadcast.com
+
+# ledgersmb development and test container created
+# from official perl images.
+
+# Dockerfile based on official ledgersmb/ledgersmb-dev-lsmb
+
+# No point installing perl libraries via apt-get as we're
+# using the official perl container, which doesn't use the
+# debian system libraries.
+#
+# gcc, cpanminus, git are already installed in the base perl image
+
+RUN echo -n "APT::Install-Recommends \"0\";\nAPT::Install-Suggests \"0\";\n" \
+       >> /etc/apt/apt.conf && \
+  DEBIAN_FRONTEND=noninteractive apt-get update && \
+  DEBIAN_FRONTEND=noninteractive apt-get -y install curl ca-certificates \
+                                            gnupg2 && \
+  curl -L https://deb.nodesource.com/setup_6.x -o ./setup && \
+  bash ./setup && rm ./setup && \
+  DEBIAN_FRONTEND=noninteractive apt-get update && \
+  DEBIAN_FRONTEND=noninteractive apt-get -y install \
+    postgresql-client \
+    texlive-latex-recommended \
+    texlive-xetex \
+    ssmtp \
+    nodejs lsb-release \
+    gettext procps  \
+  python-pip python-urllib3 python-six && \
+  pip install transifex-client && \
+  npm install -g uglify-js@">=2.0 <3.0"
+
+# 1.5 additional dependency install:
+#    JRE is for running the dojo build process using ClosureCompiler
+RUN DEBIAN_FRONTEND=noninteractive apt-get -y install \
+      default-jre-headless
+
+# Build time variables
+ENV NODE_PATH /usr/local/lib/node_modules
+ARG CACHEBUST
+
+# Install LedgerSMB
+RUN cd /srv && mkdir ledgersmb && cd ledgersmb && \
+  wget https://github.com/ledgersmb/LedgerSMB/raw/master/cpanfile && \
+  cpanm --quiet --notest \
+    --with-develop \
+    --with-feature=starman \
+    --with-feature=latex-pdf-images \
+    --with-feature=latex-pdf-ps \
+    --with-feature=openoffice \
+    --with-feature=xls \
+    --with-feature=edi \
+    --installdeps . && \
+  rm cpanfile && \
+  wget https://github.com/ledgersmb/LedgerSMB/raw/1.5/cpanfile && \
+  cpanm --quiet --notest \
+    --with-develop \
+    --with-feature=starman \
+    --with-feature=latex-pdf-images \
+    --with-feature=latex-pdf-ps \
+    --with-feature=openoffice \
+    --with-feature=edi \
+    --installdeps . && \
+  rm cpanfile && \
+  cpanm --quiet --notest Pod::ProjectDocs && \
+  rm -rf ~/.cpanm && \
+  cd .. && rm -rf ledgersmb && mkdir ledgersmb
+
+# Configure outgoing mail to use host, other run time variable defaults
+
+## sSMTP
+ENV SSMTP_ROOT ar@example.com
+ENV SSMTP_MAILHUB 172.17.0.1
+ENV SSMTP_HOSTNAME 172.17.0.1
+#ENV SSMTP_USE_STARTTLS
+#ENV SSMTP_AUTH_USER
+#ENV SSMTP_AUTH_PASS
+ENV SSMTP_FROMLINE_OVERRIDE YES
+#ENV SSMTP_AUTH_METHOD
+
+ENV POSTGRES_HOST postgres
+ENV POSTGRES_PORT 5432
+ENV DEFAULT_DB lsmb
+
+COPY start.sh /usr/local/bin/start.sh
+COPY update_ssmtp.sh /usr/local/bin/update_ssmtp.sh
+
+RUN chown www-data /etc/ssmtp /etc/ssmtp/ssmtp.conf && \
+  chmod +x /usr/local/bin/update_ssmtp.sh /usr/local/bin/start.sh && \
+  mkdir -p /var/www
+
+# Work around an aufs bug related to directory permissions:
+RUN mkdir -p /tmp && \
+  chmod 1777 /tmp
+
+# Internal Port Expose
+EXPOSE 5762
+# If ledgersmb.conf does not exist, www-data user needs to be able to create it.
+RUN chown www-data /srv/ledgersmb
+USER www-data
+
+WORKDIR /srv/ledgersmb
+
+CMD ["start.sh"]

--- a/ledgersmb-dev-perl-5.26/README.md
+++ b/ledgersmb-dev-perl-5.26/README.md
@@ -1,0 +1,111 @@
+# ledgersmb-docker
+Dockerfile for LedgerSMB Docker image
+
+This is a work in progress to make a docker image for running LedgerSMB. It should not be relied upon for production use!
+
+# Supported tags and respective `Dockerfile` links
+
+-	`dev-master` - Master branch from git, unstable
+- `1.5`, `1.5.x`, `latest` - Latest release tarball from 1.5 branch
+- `1.4`, `1.4.x` - Latest tagged release of git 1.4 branch
+
+
+# What is LedgerSMB?
+The LedgerSMB project's priority is to provide an extremely capable yet user-friendly accounting and ERP solution to small to mid-size businesses in all locales where there is interest in using the software. The focus on small to mid-size businesses offers an opportunity to provide a positive user experience in ways which are not present in larger organizations. LedgerSMB ought to strive to be both the ideal SMB accounting/ERP package and also a solution that a start-up will never outgrow. The goals mentioned above will help us provide this ideal solution by allowing us to focus both on technical architecture and on user experience.
+
+
+# How is this image designed to be used?
+
+This Docker image is built to provide a self-contained LedgerSMB instance. To be functional, you need to connect it to a running Postgres installation. The official Postgres container will work as is, if you link it to the LedgerSMB instance at startup, or you can provide environment variables to an appropriate Postgres server.
+
+LedgerSMB provides an http interface built on Starman out of the box, listening on port 5762. We do not recommend exposing this port, because we strongly recommend encrypting all connections using SSL/TLS. For production use, we recommend running a web server configured with SSL, such as Nginx or Apache, and proxying connections to LedgerSMB.
+
+The other services you will need to put this in production are an SMTP gateway (set environment variables for SSMTP at container startup) and optionally a local print server (e.g. CUPS) installation. The print service is not currently supported in this Docker image, but pull requests are welcomed ;-)
+
+
+# How to use this image
+
+## Start a postgres instance
+
+	docker run --name some-postgres -e POSTGRES_PASSWORD=mysecretpassword -d postgres
+
+This image includes `EXPOSE 5432` (the postgres port), so standard container linking will make it automatically available to the linked containers. The default `postgres` user and database are created in the entrypoint with `initdb`.
+
+> The postgres database is a default database meant for use by users, utilities and third party applications.  
+> [postgresql.org/docs](http://www.postgresql.org/docs/9.3/interactive/app-initdb.html)
+
+## Start LedgerSMB
+
+	docker run --name myledger --link some-postgres:postgres -d ledgersmb/ledgersmb
+
+## Set up LedgerSMB
+
+Visit http://myledger:5762/setup.pl (you can forward port 5762 to the host machine, or lookup the IP address for the "myledger" container if running on localhost)
+
+Log in with the "postgres" user and the password you set when starting up the Postgres container, and provide the name of a company database you want to create.
+
+Once you have completed the setup, you have a fully functional LedgerSMB instance running!
+
+Visit http://myledger:5762/login.pl to log in and get started.
+
+# Updating the LedgerSMB container
+
+No persistant data is stored in the LedgerSMB container. All LedgerSMB data is stored in Postgres, so you can stop/destroy/run a new LedgerSMB container, and as long as you link it to the Postgres database, you should be able to pick up where you left off.
+
+# Environment Variables
+
+The LedgerSMB image uses several environment variables which are easy to miss. While none of the variables are required, they may significantly aid you in using the image.
+
+### `POSTGRES_HOST` = 'postgres'
+
+This environment variable is used to specify the hostname of the Postgres server. The default is "postgres", which will find the container linked in.
+
+If you set this to another hostname, LedgerSMB will attempt to connect to that hostname instead.
+
+## `POSTGRES_PORT` = 5432
+
+Port to connect to Postgres on. Use to connect to a Postgres server running on an alternate port.
+
+## `DEFAULT_DB` = lsmb
+
+Set this if you want to automatically log in to a particular LSMB database.
+
+### `SSMTP_ROOT` `SSMTP_MAILHUB` `SSMTP_HOSTNAME` `SSMTP_USE_STARTTLS` `SSMTP_AUTH_USER` `SSMTP_AUTH_PASS` `SSMTP_METHOD` `SSMTP_FROMLINE_OVERRIDE`
+
+These variables are used to set outgoing SMTP defaults. To set the outgoing email address, set SSMTP_ROOT, and SSMTP_HOSTNAME at a minimum -- SSMTP_MAILHUB defaults to the default docker0 interface, so if your host is already configured to relay mail, this should relay successfully with only those two set.
+
+Use the other environment variables to relay mail through another host.
+
+# Troubleshooting/Developing
+
+You can connect to a running container using:
+
+> docker exec -ti myledger /bin/bash
+
+... this will give you a shell inside the container where you can inspect/troubleshoot the installation.
+
+Currently the LedgerSMB installation is in /srv/ledgersmb, and the startup/config script is /usr/bin/start.sh.
+
+
+# Supported Docker versions
+
+This image is officially supported on Docker version 1.11.1.
+
+Support for older versions is provided on a best-effort basis.
+
+# User Feedback
+
+## Documentation
+
+This is a brand new effort, and we will be adding documentation to the http://ledgersmb.org site when we get a chance.
+
+## Issues
+
+If you have any problems with or questions about this image or LedgerSMB, please contact us on the [mailing list](http://ledgersmb.org/topic/support/mailing-lists-rss-and-nntp-feeds) or through a [GitHub issue](https://github.com/ledgersmb/ledgersmb-docker/issues).
+
+You can also reach some of the official LedgerSMB maintainers via the `#ledgersmb` IRC channel on [Freenode](https://freenode.net), or on the bridged [Matrix](https://matrix.org) room in [#ledgersmb:matrix.org](https://matrix.to/#/#ledgersmb:matrix.org). The [Vector.im](https://vector.im/beta/#/room/#ledgersmb:matrix.org) Matrix client is highly recommended.
+
+
+## Contributing
+
+You are invited to contribute new features, fixes, or updates, large or small; we are always thrilled to receive pull requests, and do our best to process them as fast as we can.

--- a/ledgersmb-dev-perl-5.26/start.sh
+++ b/ledgersmb-dev-perl-5.26/start.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+update_ssmtp.sh
+cd /srv/ledgersmb
+
+if [[ ! -f ledgersmb.conf ]]; then
+  cp conf/ledgersmb.conf.default ledgersmb.conf
+  sed -i \
+    -e "s/\(cache_templates = \).*\$/cache_templates = 1/g" \
+    -e "s/\(host = \).*\$/\1$POSTGRES_HOST/g" \
+    -e "s/\(port = \).*\$/\1$POSTGRES_PORT/g" \
+    -e "s/\(default_db = \).*\$/\1$DEFAULT_DB/g" \
+    -e "s%\(sendmail   = \).*%\1/usr/sbin/ssmtp%g" \
+    /srv/ledgersmb/ledgersmb.conf
+fi
+
+# Currently unmaintained/untested
+# if [ ! -z ${CREATE_DATABASE+x} ]; then
+#   perl tools/dbsetup.pl --company $CREATE_DATABASE \
+#   --host $POSTGRES_HOST \
+#   --postgres_password "$POSTGRES_PASS"
+#fi
+
+# start ledgersmb
+exec starman --port 5762 --preload-app tools/starman.psgi

--- a/ledgersmb-dev-perl-5.26/update_ssmtp.sh
+++ b/ledgersmb-dev-perl-5.26/update_ssmtp.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+ConfiguredComment='# install script update_ssmtp.sh has configured ssmtp'
+grep -qc "$ConfiguredComment" /etc/ssmtp.conf && {
+    echo "smtp configured."
+    exit
+}
+
+sed -i \
+    -e "s/\(root=\).*\$/\1$SSMTP_ROOT/g" \
+    -e "s/\(mailhub=\).*\$/\1$SSMTP_MAILHUB/g" \
+    -e "s/\(hostname=\).*\$/\1$SSMTP_HOSTNAME/g" \
+    /etc/ssmtp/ssmtp.conf
+[ -z "$SSMTP_USE_STARTTLS" ] || echo "UseSTARTTLS=$SSMTP_USE_STARTTLS" >> /etc/ssmtp/ssmtp.conf
+[ -z "$SSMTP_AUTH_USER" ] || echo "AuthUser=$SSMTP_AUTH_USER" >> /etc/ssmtp/ssmtp.conf
+[ -z "$SSMTP_AUTH_PASS" ] || echo "AuthPass=$SSMTP_AUTH_PASS" >> /etc/ssmtp/ssmtp.conf
+[ -z "$SSMTP_AUTH_METHOD" ] || echo "AuthMethod=$SSMTP_AUTH_METHOD" >> /etc/ssmtp/ssmtp.conf
+[ -z "$SSMTP_FROMLINE_OVERRIDE" ] || echo "FromLineOverride=$SSMTP_FROMLINE_OVERRIDE" >> /etc/ssmtp/ssmtp.conf
+echo "$ConfiguredComment" >> /etc/ssmtp/ssmtp.conf


### PR DESCRIPTION
**This PR is for consideration only if PR #8 is rejected.**

This commit adds docker build contexts based on the official perl images for the different versions of perl LedgerSMB supports. These provide a consistent and repeatable way to test lsmb against a specific version.



