### PR TITLE
improve formatting of the container names

### DIFF
--- a/lsmb-dev
+++ b/lsmb-dev
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-export COMPOSE_PROJECT_NAME=ld$1
+export COMPOSE_PROJECT_NAME=ld_$1
 shift
 
 # define a log output function


### PR DESCRIPTION
- Insert an `_` after the `ld` prefix for the container names
This improves human readability