### PR TITLE
Add MailHog to catch e-mail sent during lsmb development

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,10 @@ Provides `docker-compose` infrastructure to kick off a local development
 and test environment for LedgerSMB.
 
 The infrastructure is based on the `ledgersmb/ledgersmb-dev-postgres` and
-`ledgersmb/ledgersmb-dev-lsmb` LedgerSMB containers and the `wernight/phantomjs`
-selenium tester container. The postgres container is derived from the standard
+`ledgersmb/ledgersmb-dev-lsmb` LedgerSMB containers, the `wernight/phantomjs`
+selenium tester container and the `mailhog/mailhog` mail testing tool.
+
+The postgres container is derived from the standard
 postgres container, adding the `pgTAP` test infrastructure. The lsmb container
 holds everything required to run and test LedgerSMB. This container currently
 supports versions 1.5 and master.
@@ -45,3 +47,16 @@ Running:
 Will create a new docker context for the specified perl version, from
 which an image can be built and used in place of the oficial
 `ledgersmb/ledgersmb-dev-lsmb` image.
+
+# MailHog
+
+The default configuration, all mail sent from ledgersmb is 'caught' by
+[MailHog](https://github.com/mailhog/MailHog). This allows e-mail
+functionaility to be tested without sending real messages over the
+internet.
+
+MailHog traps all messages, providing a web UI and API to view or retrieve
+them.
+
+The `mailhog/mailhog` container serves the web API on port 8025 and accepts
+SMTP connections on port 1025.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,10 @@
 version: "3.2"
 services:
+  mailhog:
+    image: mailhog/mailhog
+    expose:
+      - 1025
+      - 8025
   db:
     image: ledgersmb/ledgersmb-dev-postgres
 #    container_name: postgres-lsmb-devel
@@ -21,6 +26,7 @@ services:
     depends_on:
       - db
       - selenium
+      - mailhog
     image: ${LSMB_IMAGE:-ledgersmb/ledgersmb-dev-lsmb}
 #    container_name: lsmb-devel
     links:

--- a/ledgersmb/start.sh
+++ b/ledgersmb/start.sh
@@ -10,7 +10,9 @@ if [[ ! -f ledgersmb.conf ]]; then
     -e "s/\(host = \).*\$/\1$POSTGRES_HOST/g" \
     -e "s/\(port = \).*\$/\1$POSTGRES_PORT/g" \
     -e "s/\(default_db = \).*\$/\1$DEFAULT_DB/g" \
-    -e "s%\(sendmail   = \).*%\1/usr/sbin/ssmtp%g" \
+    -e "s%\(sendmail   = \).*%#\1/usr/sbin/ssmtp%g" \
+    -e "s/# \(smtphost = \).*\$/\1mailhog:1025/g" \
+    -e "s/# \(backup_email_from = \).*\$/\1lsmb-backups@example.com/g" \
     /srv/ledgersmb/ledgersmb.conf
 fi
 


### PR DESCRIPTION
Default configuration updated so that mail sent from lsmb is
directed to the MailHog container.

The MailHog container accepts smtp connections on port 1025.

It provides a web UI and api to view and retrieve messages on
port 8025.