### PR TITLE
Fix BASE_URL env variables so that tests can run

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,8 +36,8 @@ services:
         target: /srv/ledgersmb
         source: ${PWD}
     environment:
-      LSMB_BASE_URL: http://lsmb-devel:5762
-      PSGI_BASE_URL: http://lsmb-devel:5762
+      LSMB_BASE_URL: http://ledgersmbdevdocker_lsmb_1:5762
+      PSGI_BASE_URL: http://ledgersmbdevdocker_lsmb_1:5762
       LSMB_TEST_DB: 1
       LSMB_NEW_DB: lsmbtestdb
       COA_TESTING: 1


### PR DESCRIPTION
`xt/60-startlsmb.t` requires that `LSMB_BASE_URL` is valid and fails
without meaningful error message if not. As a result, tests were
broken with the ledgersmb-dev-docker containers.