### PR TITLE
Move from PhantomJS to a Selenium grid

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 docker-compose-local.yml
+.local

--- a/README.md
+++ b/README.md
@@ -85,13 +85,13 @@ http://172.20.0.6/login.pl allows to log into the company.
 
 Three commands exist to run tests:
 
-* `make test`
+* `make test`\
    Runs the tests in the `t/` directory
-* `make devtest`
+* `make devtest`\
    Runs the tests in the `t/` and `xt/` directories
-* `make pherkin`
+* `make pherkin`\
   Runs the tests `xt/**/*.feature`
-
+\
 The set of tests to be run can be restricted using the `TESTS` Makefile
 variable:
 

--- a/README.md
+++ b/README.md
@@ -38,19 +38,27 @@ http://172.20.0.6
 ======================================
 ```
 
-Five containers are created:
+Ten containers are created:
 
 * `ldmaster_db_1`
 * `ldmaster_lsmb_1`
-* `ldmaster_selenium_1`
 * `ldmaster_mailhog_1`
 * `ldmaster_proxy_1`
+* `ldmaster_selenium_1`
+* `ldmaster_chrome_1`
+* `ldmaster_chrome_2`
+* `ldmaster_chrome_3`
+* `ldmaster_chrome_4`
+* `ldmaster_chrome_5`
 
 The `LedgerSMB` directory is mapped to the `/srv/ledgersmb` directory
 inside the `ldmaster_lsmb_1` and `ldmaster_proyxy_1` containers. The
 database container creates its database storage on a "RAM drive",
 meaning that restarting the container causes all existing databases
 to be flushed.
+
+A Selenium grid is created with a hub and 5 copies of the browser you selected,
+Chrome is set per default. Firefox and Opera are supported.
 
 ## Creating JavaScript output
 
@@ -77,13 +85,13 @@ http://172.20.0.6/login.pl allows to log into the company.
 
 Three commands exist to run tests:
 
-* `make test`  
+* `make test`
    Runs the tests in the `t/` directory
-* `make devtest`  
+* `make devtest`
    Runs the tests in the `t/` and `xt/` directories
-* `make pherkin`  
+* `make pherkin`
   Runs the tests `xt/**/*.feature`
-  
+
 The set of tests to be run can be restricted using the `TESTS` Makefile
 variable:
 
@@ -143,15 +151,20 @@ $ git clone -b 1.8 https://github.com/ledgersmb/LedgerSMB.git
 $ git clone https://github.com/ledgersmb/ledgersmb-dev-docker.git ldd
 $ cd LedgerSMB
 $ ../ldd/lsmb-dev 18 pull
-$ ../ldd/lsmb-dev 18 up -d
+$ BROWSER=firefox ../ldd/lsmb-dev 18 up -d
 ```
-This creates 5 additional containers:
+This creates 10 additional containers:
 * `ld18_db_1`
 * `ld18_lsmb_1`
 * `ld18_selenium_1`
 * `ld18_mailhog_1`
 * `ld18_proxy_1`
-
+* `ld18_selenium_1`
+* `ld18_firefox_1`
+* `ld18_firefox_2`
+* `ld18_firefox_3`
+* `ld18_firefox_4`
+* `ld18_firefox_5`
 
 
 # DB (PostgreSQL)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,7 +60,7 @@ services:
       - LSMB_BASE_URL=http://proxy:80
       - PSGI_BASE_URL=http://lsmb:5762
       - LSMB_TEST_DB=1
-      - LSMB_NEW_DB=lsmbtestdb
+      - LSMB_NEW_DB=lsmb_test
       - COA_TESTING=1
       - REMOTE_SERVER_ADDR=selenium
       - BROWSER=${BROWSER:-chrome}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,12 @@
 version: "3.2"
+
 services:
   mailhog:
     image: mailhog/mailhog
     expose:
       - 1025
       - 8025
+
   db:
     image: ledgersmb/ledgersmb-dev-postgres
     environment:
@@ -12,14 +14,7 @@ services:
       PGDATA: /var/lib/postgresql/data/pgdata
     volumes:
       - dbdata:/var/lib/postgresql/data
-  selenium:
-    image: wernight/phantomjs:2.1.1
-    command: phantomjs --webdriver=4422
-    stop_signal: SIGKILL
-    expose:
-      - 4422
-    environment:
-      LANG: en_US.UTF-8
+
   lsmb:
     depends_on:
       - db
@@ -32,7 +27,6 @@ services:
     volumes:
       - type: bind
         target: /srv/ledgersmb
-#        target: /home/circleci
         source: ${PWD}
     environment:
       - PLACK_SERVER=HTTP::Server::Simple
@@ -47,27 +41,28 @@ services:
       - LSMB_NEW_DB=lsmbtestdb
       - COA_TESTING=1
       - REMOTE_SERVER_ADDR=selenium
+      - BROWSER=${BROWSER:-chrome}
       - PGHOST=postgres
       - PGUSER=postgres
       - PGPASSWORD=abc
       - SSMTP_HOSTNAME=mailhog
       - SSMTP_MAILHUB=mailhog:1025
+
   proxy:
     image: ledgersmb/ledgersmb-dev-nginx
     expose:
-      - 80
+      - 5000
+    ports:
+      - 5000:80
     depends_on:
       - lsmb
     volumes:
       - type: bind
-#        target: /home/circleci
         target: /srv/ledgersmb
         source: ${PWD}
-
 
 volumes:
   dbdata:
     driver_opts:
       type: tmpfs
       device: tmpfs
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,6 +86,8 @@ services:
       - type: bind
         target: /srv/ledgersmb
         source: ${PWD}
+      # Uncomment to override the default configuration
+      - ../ldd/nginx/nginx.conf:/etc/nginx/nginx.conf:ro
     networks:
       - default
       - internal

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,6 +72,7 @@ services:
     networks:
       - internal
       - default
+      - grid
 
   proxy:
     image: ledgersmb/ledgersmb-dev-nginx
@@ -90,6 +91,7 @@ services:
     networks:
       - default
       - internal
+      - grid
 
 volumes:
   dbdata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,18 @@
 version: "3.2"
 
+networks:
+  internal:
+    driver: bridge
+    internal: yes
+
 services:
   mailhog:
     image: mailhog/mailhog
     expose:
       - 1025
       - 8025
+    networks:
+      - internal
 
   db:
     image: ledgersmb/ledgersmb-dev-postgres
@@ -14,6 +21,8 @@ services:
       PGDATA: /var/lib/postgresql/data/pgdata
     volumes:
       - dbdata:/var/lib/postgresql/data
+    networks:
+      - internal
 
   lsmb:
     depends_on:
@@ -24,10 +33,14 @@ services:
     image: ${LSMB_IMAGE:-ledgersmb/ledgersmb-dev-lsmb}
     links:
       - "db:postgres"
+      - selenium
     volumes:
       - type: bind
         target: /srv/ledgersmb
         source: ${PWD}
+      - type: bind
+        target: $HOME
+        source: $HOME
       - /etc/group:/etc/group:ro
       - /etc/passwd:/etc/passwd:ro
       - /etc/shadow:/etc/shadow:ro
@@ -37,6 +50,7 @@ services:
       - RELEASE_TESTING=1
       - HARNESS_RULESFILE="t/testrules.yml"
       - DEVEL_COVER_OPTIONS
+      - LANG=C.UTF-8
       - LSMB_BASE_URL=http://proxy:80
       - PSGI_BASE_URL=http://lsmb:5762
       - LSMB_TEST_DB=1
@@ -49,6 +63,9 @@ services:
       - PGPASSWORD=abc
       - SSMTP_HOSTNAME=mailhog
       - SSMTP_MAILHUB=mailhog:1025
+    networks:
+      - internal
+      - default
 
   proxy:
     image: ledgersmb/ledgersmb-dev-nginx
@@ -62,6 +79,9 @@ services:
       - type: bind
         target: /srv/ledgersmb
         source: ${PWD}
+    networks:
+      - default
+      - internal
 
 volumes:
   dbdata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,12 +78,10 @@ services:
     image: ledgersmb/ledgersmb-dev-nginx
     hostname: ${COMPOSE_PROJECT_NAME}_proxy
     container_name: ${COMPOSE_PROJECT_NAME}_proxy
-    expose:
-      - 5000
-    ports:
-      - 5000:80
     depends_on:
       - lsmb
+    ports:
+      - 80
     volumes:
       - type: bind
         target: /srv/ledgersmb

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
   db:
     image: ledgersmb/ledgersmb-dev-postgres
     environment:
-      POSTGRES_PASSWORD: abc
+      POSTGRES_PASSWORD: ${PGPASSWORD:-abc}
       PGDATA: /var/lib/postgresql/data/pgdata
     volumes:
       - dbdata:/var/lib/postgresql/data
@@ -40,7 +40,7 @@ services:
         source: ${PWD}
       - type: bind
         target: $HOME
-        source: $HOME
+        source: $HOME_DEV
       - /etc/group:/etc/group:ro
       - /etc/passwd:/etc/passwd:ro
       - /etc/shadow:/etc/shadow:ro
@@ -60,7 +60,7 @@ services:
       - BROWSER=${BROWSER:-chrome}
       - PGHOST=postgres
       - PGUSER=postgres
-      - PGPASSWORD=abc
+      - PGPASSWORD=${PGPASSWORD:-abc}
       - SSMTP_HOSTNAME=mailhog
       - SSMTP_MAILHUB=mailhog:1025
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ networks:
 services:
   mailhog:
     image: mailhog/mailhog
+    hostname: mailhog
+    container_name: ${COMPOSE_PROJECT_NAME}_mailhog
     expose:
       - 1025
       - 8025
@@ -16,6 +18,8 @@ services:
 
   db:
     image: ledgersmb/ledgersmb-dev-postgres
+    hostname: db
+    container_name: ${COMPOSE_PROJECT_NAME}_db
     environment:
       POSTGRES_PASSWORD: ${PGPASSWORD:-abc}
       PGDATA: /var/lib/postgresql/data/pgdata
@@ -31,6 +35,8 @@ services:
       - mailhog
     user: "${USER}"
     image: ${LSMB_IMAGE:-ledgersmb/ledgersmb-dev-lsmb}
+    hostname: lsmb
+    container_name: ${COMPOSE_PROJECT_NAME}_lsmb
     links:
       - "db:postgres"
       - selenium
@@ -69,6 +75,8 @@ services:
 
   proxy:
     image: ledgersmb/ledgersmb-dev-nginx
+    hostname: ${COMPOSE_PROJECT_NAME}_proxy
+    container_name: ${COMPOSE_PROJECT_NAME}_proxy
     expose:
       - 5000
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,9 @@ services:
       - type: bind
         target: /srv/ledgersmb
         source: ${PWD}
+      - /etc/group:/etc/group:ro
+      - /etc/passwd:/etc/passwd:ro
+      - /etc/shadow:/etc/shadow:ro
     environment:
       - PERL5OPT
       - HARNESS_PERL_SWITCHES

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -81,7 +81,7 @@ services:
     depends_on:
       - lsmb
     ports:
-      - 80
+      - ${LSMB_PORT:-0}:80
     volumes:
       - type: bind
         target: /srv/ledgersmb

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,6 @@ services:
         target: /srv/ledgersmb
         source: ${PWD}
     environment:
-      - PLACK_SERVER=HTTP::Server::Simple
       - PERL5OPT
       - HARNESS_PERL_SWITCHES
       - RELEASE_TESTING=1

--- a/ledgersmb/Dockerfile
+++ b/ledgersmb/Dockerfile
@@ -1,5 +1,5 @@
 FROM        debian:buster
-MAINTAINER  Freelock john@freelock.com
+LABEL       maintainer="Freelock john@freelock.com"
 
 
 # Install Perl, Tex, Starman, psql client, and all dependencies
@@ -14,7 +14,7 @@ RUN echo -n "APT::Install-Recommends \"0\";\nAPT::Install-Suggests \"0\";\n" \
   DEBIAN_FRONTEND="noninteractive" apt-get -y update && \
   DEBIAN_FRONTEND="noninteractive" apt-get -y install curl ca-certificates \
                                       wget gnupg2 && \
-  curl -L https://deb.nodesource.com/setup_12.x -o ./setup && \
+  curl -L https://deb.nodesource.com/setup_15.x -o ./setup && \
   bash ./setup && rm ./setup && \
   DEBIAN_FRONTEND="noninteractive" apt-get -y update && \
   DEBIAN_FRONTEND="noninteractive" apt-get -y upgrade && \

--- a/ledgersmb/Dockerfile
+++ b/ledgersmb/Dockerfile
@@ -149,6 +149,9 @@ ENV POSTGRES_HOST postgres
 ENV POSTGRES_PORT 5432
 ENV DEFAULT_DB lsmb
 
+# Upgrade npm from v6 provided by buster
+RUN sudo npm install -g npm@7.14.0
+
 COPY start.sh /usr/local/bin/start.sh
 
 RUN chmod +x /usr/local/bin/start.sh && \

--- a/ledgersmb/start.sh
+++ b/ledgersmb/start.sh
@@ -25,3 +25,7 @@ fi
 PERL5OPT="$PERL5OPT $HARNESS_PERL_SWITCHES"
 export PERL5OPT
 exec plackup -I/srv/ledgersmb/lib -I/srv/ledgersmb/old/lib --port 5762 $psgi_app
+
+if [[ -x .local/start.sh ]]
+   .local/start.sh
+fi

--- a/ledgersmb/start.sh
+++ b/ledgersmb/start.sh
@@ -21,6 +21,10 @@ else
    psgi_app=/srv/ledgersmb/tools/starman.psgi
 fi
 
+# Allow ledgersmb-admin to work
+PERL5LIB=lib
+export PERL5LIB
+
 # start ledgersmb
 PERL5OPT="$PERL5OPT $HARNESS_PERL_SWITCHES"
 export PERL5OPT

--- a/lsmb-dev
+++ b/lsmb-dev
@@ -52,7 +52,9 @@ show_result() {
 	== LedgerSMB '$CurrentBranch'
 	== should be available at
 	======================================
-	http://${IpAddr}
+    host:  http://${IpAddr_host}:${HostPort}
+	proxy: http://${IpAddr_proxy}
+	psgi:  http://${IpAddr_lsmb}:5762
 	======================================
 
 	EOF
@@ -102,8 +104,11 @@ if test "$1" = "start" -o "$1" = "restart" -o "$1" = "up" ; then
   # don't try to report the ip and url if the command is one of
   # pull, rm, stop,
 
-  # report the IP address in the form of a URL
-  IpAddr=`docker inspect -f '{{.NetworkSettings.Networks.ldmaster_default.IPAddress}}' "${COMPOSE_PROJECT_NAME}_proxy_1"`
+  # report the IP address in the form of URLs
+  HostPort=`docker inspect --format='{{(index (index .NetworkSettings.Ports "80/tcp") 0).HostPort}}' "${COMPOSE_PROJECT_NAME}_proxy"`
+  IpAddr_host=`hostname`
+  IpAddr_proxy=`docker inspect -f "{{.NetworkSettings.Networks.${COMPOSE_PROJECT_NAME}_default.IPAddress}}" "${COMPOSE_PROJECT_NAME}_proxy"`
+  IpAddr_lsmb=`docker inspect -f "{{.NetworkSettings.Networks.${COMPOSE_PROJECT_NAME}_default.IPAddress}}" "${COMPOSE_PROJECT_NAME}_lsmb"`
 
   show_result
 elif test "$1" = "rm"; then

--- a/lsmb-dev
+++ b/lsmb-dev
@@ -88,7 +88,7 @@ if test "$1" = "up" ; then
 fi
 
 # generate and start the containers
-USER="$UID:$GID" docker-compose \
+USER="$(id -u):$(id -g)" docker-compose \
     -f $_CWD/selenium/docker-compose.yml \
     -f $_CWD/selenium/docker-compose-$BROWSER.yml \
     -f "$F" "$@" $SCALE

--- a/lsmb-dev
+++ b/lsmb-dev
@@ -106,6 +106,11 @@ if test "$1" = "start" -o "$1" = "restart" -o "$1" = "up" ; then
   IpAddr=`docker inspect -f '{{.NetworkSettings.Networks.ldmaster_default.IPAddress}}' "${COMPOSE_PROJECT_NAME}_proxy_1"`
 
   show_result
+elif test "$1" = "rm"; then
+  # Remove networks
+  docker network rm ${COMPOSE_PROJECT_NAME}_default
+  docker network rm ${COMPOSE_PROJECT_NAME}_grid
+  docker network rm ${COMPOSE_PROJECT_NAME}_internal
 fi
 
 if ! test -e Makefile.local ; then

--- a/lsmb-dev
+++ b/lsmb-dev
@@ -28,7 +28,7 @@ show_logs() { # shows the last 5 minutes of logs for the lsmb container
 	EOF
 
     sleep 5; # need a little time for the logs to get updated unfortunately
-    docker logs --since $(( `date "+%s"` - (5*60) )) "${COMPOSE_PROJECT_NAME}_lsmb_1";
+    docker logs --since $(( `date "+%s"` - (5*60) )) "${COMPOSE_PROJECT_NAME}_lsmb";
 
     cat <<-EOF
 
@@ -40,7 +40,7 @@ show_logs() { # shows the last 5 minutes of logs for the lsmb container
 
 is_container_running() {
     local z;
-    z=`docker ps --filter "status=running" --filter="name=${COMPOSE_PROJECT_NAME}_lsmb_1" --quiet 2>/dev/null`;
+    z=`docker ps --filter "status=running" --filter="name=${COMPOSE_PROJECT_NAME}_lsmb" --quiet 2>/dev/null`;
     test -n "$z";
 }
 
@@ -110,7 +110,7 @@ fi
 
 if ! test -e Makefile.local ; then
     cat >Makefile.local <<-EOF
-	CONTAINER=${COMPOSE_PROJECT_NAME}_lsmb_1
+	CONTAINER=${COMPOSE_PROJECT_NAME}_lsmb
 	#PHERKIN_EXTRA_OPTS=--theme=light
 	#DOCKER_CMD=
 	#PHERKIN_OPTS=
@@ -119,7 +119,7 @@ if ! test -e Makefile.local ; then
 
     echo "Created Makefile.local causing e.g. 'make test' to run in the container"
 else
-    if test -z "`grep ${COMPOSE_PROJECT_NAME}_lsmb_1 Makefile.local`" ; then
-        echo "'Makefile.local' missing reference to container '${COMPOSE_PROJECT_NAME}_lsmb_1\nplease update it manually"
+    if test -z "`grep ${COMPOSE_PROJECT_NAME}_lsmb Makefile.local`" ; then
+        echo "'Makefile.local' missing reference to container '${COMPOSE_PROJECT_NAME}_lsmb\nplease update it manually"
     fi
 fi

--- a/lsmb-dev
+++ b/lsmb-dev
@@ -89,16 +89,17 @@ fi
 
 # generate and start the containers
 USER="$(id -u):$(id -g)" docker-compose \
+    -f "$F" \
     -f $_CWD/selenium/docker-compose.yml \
     -f $_CWD/selenium/docker-compose-$BROWSER.yml \
-    -f "$F" "$@" $SCALE
+    "$@" $SCALE
 
 if test "$1" = "start" -o "$1" = "restart" -o "$1" = "up" ; then
   # don't try to report the ip and url if the command is one of
   # pull, rm, stop,
 
   # report the IP address in the form of a URL
-  IpAddr=`docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' "${COMPOSE_PROJECT_NAME}_proxy_1"`
+  IpAddr=`docker inspect -f '{{.NetworkSettings.Networks.ldmaster_default.IPAddress}}' "${COMPOSE_PROJECT_NAME}_proxy_1"`
 
   show_result
 fi

--- a/lsmb-dev
+++ b/lsmb-dev
@@ -2,6 +2,10 @@
 
 # set -x
 
+if [ -f ../ldd/.local/.env ]; then
+    source ../ldd/.local/.env
+fi
+
 export COMPOSE_PROJECT_NAME=ld$1
 shift
 

--- a/lsmb-dev
+++ b/lsmb-dev
@@ -5,21 +5,31 @@
 export COMPOSE_PROJECT_NAME=ld$1
 shift
 
+_CWD=$(dirname $(perl -e "use Cwd qw(realpath); print realpath '$0'"))
+
+BROWSER=${BROWSER:-chrome}
+BROWSER_COUNT=${BROWSER_COUNT:-5}
+
+if [ ! -f ../ldd/selenium/docker-compose-${BROWSER}.yml ]; then
+  echo "Unconfigured browser $BROWSER. Please define $_CWD/selenium/docker-compose-${BROWSER}.yml"
+  exit
+fi
+
 # define a log output function
 show_logs() { # shows the last 5 minutes of logs for the lsmb container
     cat <<-EOF
-	
+
 	======================================
-	
+
 	EOF
 
     sleep 5; # need a little time for the logs to get updated unfortunately
     docker logs --since $(( `date "+%s"` - (5*60) )) "${COMPOSE_PROJECT_NAME}_lsmb_1";
 
     cat <<-EOF
-	
+
 	======================================
-	
+
 	EOF
 
 }
@@ -33,14 +43,14 @@ is_container_running() {
 show_result() {
     if is_container_running; then
         cat <<-EOF
-	
+
 	======================================
 	== LedgerSMB '$CurrentBranch'
 	== should be available at
 	======================================
 	http://${IpAddr}
 	======================================
-	
+
 	EOF
         return 0
     else
@@ -60,20 +70,28 @@ if ! test -r "${DirName}/lib/LedgerSMB.pm"; then
 	== You don't appear to be running me  ==
 	== from a valid LedgerSMB repository  ==
 	========================================
-	
+
 	EOF
     exit 9
 fi
 
 # Check for a local (non repo) version of the yml file
 if test -r docker-compose-local.yml; then
-    F="$(dirname $(perl -e "use Cwd qw(realpath); print realpath '$0'"))/docker-compose-local.yml"
+    F="$_CWD/docker-compose-local.yml"
 else
-    F="$(dirname $(perl -e "use Cwd qw(realpath); print realpath '$0'"))/docker-compose.yml"
+    F="$_CWD/docker-compose.yml"
+fi
+
+SCALE=""
+if test "$1" = "up" ; then
+    SCALE="--scale $BROWSER=$BROWSER_COUNT"
 fi
 
 # generate and start the containers
-USER="$UID:$GID" docker-compose -f "$F" "$@"
+USER="$UID:$GID" docker-compose \
+    -f $_CWD/selenium/docker-compose.yml \
+    -f $_CWD/selenium/docker-compose-$BROWSER.yml \
+    -f "$F" "$@" $SCALE
 
 if test "$1" = "start" -o "$1" = "restart" -o "$1" = "up" ; then
   # don't try to report the ip and url if the command is one of

--- a/lsmb-dev
+++ b/lsmb-dev
@@ -12,7 +12,7 @@ shift
 _CWD=$(dirname $(perl -e "use Cwd qw(realpath); print realpath '$0'"))
 
 BROWSER=${BROWSER:-chrome}
-BROWSER_COUNT=${BROWSER_COUNT:-5}
+BROWSERS_COUNT=${BROWSERS_COUNT:-5}
 
 if [ ! -f ../ldd/selenium/docker-compose-${BROWSER}.yml ]; then
   echo "Unconfigured browser $BROWSER. Please define $_CWD/selenium/docker-compose-${BROWSER}.yml"
@@ -90,7 +90,7 @@ fi
 
 SCALE=""
 if test "$1" = "up" ; then
-    SCALE="--scale $BROWSER=$BROWSER_COUNT"
+    SCALE="--scale $BROWSER=$BROWSERS_COUNT"
 fi
 
 # generate and start the containers

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -52,11 +52,8 @@ http {
          proxy_pass http://lsmb:5762;
       }
 
-      location ~ ^/$ {
-         return 301 /lsmb/login.pl;
+      location = / {
+         return 301 http://$http_host/login.pl;
       }
-
    }
 }
-
-

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -37,11 +37,11 @@ http {
 
       root /srv/ledgersmb/UI;
 
-      access_log /var/log/nginx/access.log;
-      error_log /var/log/nginx/error.log;
-
-      location ~ /js/(.*) {
-         try_files /js/$1 /js-src/$1 =404;
+      # JS & CSS
+      location ~* \.(js|css)$ {
+         add_header Pragma public;
+         add_header Cache-Control "public, max-age=0, must-revalidate, proxy-revalidate";
+         try_files $uri =404;
       }
 
       location ~ \.pl$ {

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -37,8 +37,8 @@ http {
 
       root /srv/ledgersmb/UI;
 
-      # JS & CSS
-      location ~* \.(js|css)$ {
+      # Almost statics
+      location ~* \.(js|css|png|gif|ico)$ {
          add_header Pragma public;
          add_header Cache-Control "public, max-age=0, must-revalidate, proxy-revalidate";
          try_files $uri =404;

--- a/selenium/docker-compose-chrome.yml
+++ b/selenium/docker-compose-chrome.yml
@@ -1,0 +1,15 @@
+version: '3.2'
+
+services:
+
+  chrome:
+    image: selenium/node-chrome
+    depends_on:
+      - selenium
+    volumes:
+      - /dev/shm:/dev/shm
+    environment:
+      - HUB_HOST=selenium
+      - NODE_MAX_SESSION=5
+      - NODE_MAX_INSTANCES=5
+      - GRID_DEBUG=true

--- a/selenium/docker-compose-chrome.yml
+++ b/selenium/docker-compose-chrome.yml
@@ -13,3 +13,5 @@ services:
       - NODE_MAX_SESSION=5
       - NODE_MAX_INSTANCES=5
       - GRID_DEBUG=true
+    networks:
+      - grid

--- a/selenium/docker-compose-firefox.yml
+++ b/selenium/docker-compose-firefox.yml
@@ -1,0 +1,15 @@
+version: '3.2'
+
+services:
+
+  firefox:
+    image: selenium/node-firefox
+    volumes:
+      - /dev/shm:/dev/shm
+    depends_on:
+      - selenium
+    environment:
+      - HUB_HOST=selenium
+      - NODE_MAX_SESSION=5
+      - NODE_MAX_INSTANCES=5
+      - GRID_DEBUG=true

--- a/selenium/docker-compose-firefox.yml
+++ b/selenium/docker-compose-firefox.yml
@@ -13,3 +13,5 @@ services:
       - NODE_MAX_SESSION=5
       - NODE_MAX_INSTANCES=5
       - GRID_DEBUG=true
+    networks:
+      - grid

--- a/selenium/docker-compose-operablink.yml
+++ b/selenium/docker-compose-operablink.yml
@@ -1,0 +1,15 @@
+version: '3.2'
+
+services:
+
+  operablink:
+    image: selenium/node-opera
+    volumes:
+      - /dev/shm:/dev/shm
+    depends_on:
+      - selenium
+    environment:
+      - HUB_HOST=selenium
+      - NODE_MAX_SESSION=5
+      - NODE_MAX_INSTANCES=5
+      - GRID_DEBUG=true

--- a/selenium/docker-compose-operablink.yml
+++ b/selenium/docker-compose-operablink.yml
@@ -13,3 +13,5 @@ services:
       - NODE_MAX_SESSION=5
       - NODE_MAX_INSTANCES=5
       - GRID_DEBUG=true
+    networks:
+      - grid

--- a/selenium/docker-compose.yml
+++ b/selenium/docker-compose.yml
@@ -1,0 +1,19 @@
+version: '3.2'
+
+services:
+
+  selenium:
+    image: selenium/hub
+    container_name: selenium
+    hostname: selenium
+    privileged: true
+    expose:
+      - 4422
+    ports:
+      - "4422:4444"
+    volumes:
+      - /dev/shm:/dev/shm
+    environment:
+      - GRID_MAX_SESSION=50
+      - GRID_TIMEOUT=1800
+      - GRID_DEBUG=true

--- a/selenium/docker-compose.yml
+++ b/selenium/docker-compose.yml
@@ -4,13 +4,9 @@ services:
 
   selenium:
     image: selenium/hub
-    container_name: selenium
-    hostname: selenium
     privileged: true
-    expose:
-      - 4422
     ports:
-      - "4422:4444"
+      - 4444:4444
     volumes:
       - /dev/shm:/dev/shm
     environment:

--- a/selenium/docker-compose.yml
+++ b/selenium/docker-compose.yml
@@ -1,5 +1,10 @@
 version: '3.2'
 
+networks:
+  grid:
+    driver: bridge
+    internal: yes
+
 services:
 
   selenium:
@@ -15,3 +20,5 @@ services:
       - GRID_MAX_SESSION=50
       - GRID_TIMEOUT=1800
       - GRID_DEBUG=true
+    networks:
+      - grid

--- a/selenium/docker-compose.yml
+++ b/selenium/docker-compose.yml
@@ -4,6 +4,8 @@ services:
 
   selenium:
     image: selenium/hub
+    hostname: ${COMPOSE_PROJECT_NAME}_selenium
+    container_name: ${COMPOSE_PROJECT_NAME}_selenium
     privileged: true
     ports:
       - 4444:4444


### PR DESCRIPTION
This PR departs from PhantomJS to the profit of a Selenium Grid. Chrome, Firefox or Opera can be used.
It also maps the host user to the working user in the `lsmb` container and bind mount the home directory so that the user is defined.
Finally, it maps the proxy server to 5000 instead of 80 to remove conflicts with existing installations.
