### PR TITLE
Allow using gzipped statics

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -29,16 +29,18 @@ http {
    access_log /var/log/nginx/access.log;
    error_log /var/log/nginx/error.log;
 
-   gzip off;
-
    server {
       listen 80 default_server;
       listen [::]:80 default_server ipv6only=on;
 
       root /srv/ledgersmb/UI;
 
+      gzip off;
+      gzip_proxied any;
+
       # Almost statics
       location ~* \.(js|css|png|gif|ico)$ {
+         gzip_static on;
          add_header Pragma public;
          add_header Cache-Control "public, max-age=0, must-revalidate, proxy-revalidate";
          try_files $uri =404;


### PR DESCRIPTION
Allow the proxy to send gzipped statics instead of the no-compressed versions when available and allowed by the client