### PR TITLE
Fix spurious indentation in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       - dbdata:/var/lib/postgresql/data
     ports:
       - ${DB_PORT:-0}:5432
-      networks:
+    networks:
       - internal
       - default
 


### PR DESCRIPTION
Remove syntax error in docker-compose brought by bad indentation