### PR TITLE
Allow triggered build from Ledgersmb/master merge

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,6 +1,14 @@
 name: Docker Image CI
 
-on: [push, pull_request]
+on: 
+  push:
+    branches-ignore:
+      - 'master'
+  pull_request:
+    branches:
+      - '*'
+  repository_dispatch:
+    types: [master-updated]
 
 jobs:
   ledgersmb:


### PR DESCRIPTION
Answer to a build request from LedgerSMB/master merge to synchronize the development docker images