### PR TITLE
Only rebuild ledgersmb on master changes

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -12,6 +12,7 @@ on:
     types: [master-updated]
 
 jobs:
+
   ledgersmb:
     runs-on: ubuntu-latest
     steps:
@@ -27,8 +28,10 @@ jobs:
         context: ledgersmb
         push_git_tag: ${{ github.event_name == 'push' || github.event.pull_request.merged }}
         push_image_and_stages: ${{ github.event_name == 'push' || github.event.pull_request.merged }}
+
   proxy:
     runs-on: ubuntu-latest
+    if: github.event.action != "master-updated"
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
@@ -42,8 +45,10 @@ jobs:
         push_git_tag: ${{ github.event_name == 'push' || github.event.pull_request.merged }}
         context: nginx
         push_image_and_stages: ${{ github.event_name == 'push' || github.event.pull_request.merged }}
+
   postgres:
     runs-on: ubuntu-latest
+    if: github.event.action != "master-updated"
     steps:
     - name: Checkout code
       uses: actions/checkout@v2


### PR DESCRIPTION
Remote triggered builds only concern ledgersmb, not the proxy or the database