### PR TITLE
Revise ports reported during startup

### DIFF
--- a/lsmb-dev
+++ b/lsmb-dev
@@ -69,8 +69,10 @@ show_result() {
     IpAddr_host=`hostname`
     IpAddr_db=`docker inspect -f "{{.NetworkSettings.Networks.${COMPOSE_PROJECT_NAME}_default.IPAddress}}" "${COMPOSE_PROJECT_NAME}_db"`
     IpAddr_mailhog=`docker inspect -f "{{.NetworkSettings.Networks.${COMPOSE_PROJECT_NAME}_default.IPAddress}}" "${COMPOSE_PROJECT_NAME}_mailhog"`
+    Port_mailhog=`docker inspect --format='{{(index (index .NetworkSettings.Ports "8025/tcp") 0).HostPort}}' "${COMPOSE_PROJECT_NAME}_mailhog"`
     IpAddr_proxy=`docker inspect -f "{{.NetworkSettings.Networks.${COMPOSE_PROJECT_NAME}_default.IPAddress}}" "${COMPOSE_PROJECT_NAME}_proxy"`
     IpAddr_lsmb=`docker inspect -f "{{.NetworkSettings.Networks.${COMPOSE_PROJECT_NAME}_default.IPAddress}}" "${COMPOSE_PROJECT_NAME}_lsmb"`
+    Port_lsmb=`docker inspect --format='{{(index (index .NetworkSettings.Ports "9000/tcp") 0).HostPort}}' "${COMPOSE_PROJECT_NAME}_lsmb"`
 
     cat <<-EOF
 	======================================
@@ -78,20 +80,23 @@ show_result() {
 	== should be available at
 	======================================
 	host         : http://${IpAddr_host}:${HostPort}
+	mailhog      : http://${IpAddr_host}:${Port_mailhog}
+	dev (login)* : http://${IpAddr_host}:${Port_lsmb}/login.pl
+	dev (setup)* : http://${IpAddr_host}:${Port_lsmb}/setup.pl
+	db           : postgresql://${IpAddr_host}:${DBPort}
+	
 	mailhog      : http://${IpAddr_mailhog}:8025
 	psgi         : http://${IpAddr_lsmb}:5762
 	proxy (login): http://${IpAddr_proxy}/login.pl
 	proxy (setup): http://${IpAddr_proxy}/setup.pl
-	dev (login)  : http://${IpAddr_lsmb}:9000/login.pl
-	dev (setup)  : http://${IpAddr_lsmb}:9000/setup.pl
+	dev (login)* : http://${IpAddr_lsmb}:9000/login.pl
+	dev (setup)* : http://${IpAddr_lsmb}:9000/setup.pl
+	db           : postgresql://${IpAddr_db}:5432
 	======================================
-	== Postgres Database can be accessed at
-	======================================
-	db:  ${IpAddr_host}:${DBPort}
-	db:  ${IpAddr_db}:5432
-	======================================
+	* Only available if 'make serve' is running.	
 	EOF
 }
+
 
 # Check we are actually in a LedgerSMB repo
 DirName=`git rev-parse --show-toplevel`; # retrieve the git toplevel dir


### PR DESCRIPTION
Add 2 additional ports that were present but not reported
Reformat the reported ports into sections for external and internal
Change the 'db' line to be a postgres URL for consistency with other URLs
Minor revisions to README.md for grammer and clarity
Correct error in how tests are run in parallel in README.md